### PR TITLE
Fix build of sepolicy on Marshmallow

### DIFF
--- a/sepolicy.mk
+++ b/sepolicy.mk
@@ -1,0 +1,3 @@
+# SELinux
+BOARD_SEPOLICY_DIRS += device/sony/sepolicy
+


### PR DESCRIPTION
Building without sepolicy would be a very bad idea. This ensures build fails without it.

Signed-off-by: Adam Farden <adam@farden.cz>