### PR TITLE
Label timekeep_app as system_data_file

### DIFF
--- a/file.te
+++ b/file.te
@@ -63,7 +63,6 @@ type proc_kernel_sched, fs_type;
 
 type acdb_data_file, file_type, data_file_type;
 type addrsetup_data_file, file_type, data_file_type;
-type timekeep_app_data_file, file_type, data_file_type;
 
 type sysfs_addrsetup, fs_type, sysfs_type;
 type sysfs_fingerprintd_writable, fs_type, sysfs_type;

--- a/installd.te
+++ b/installd.te
@@ -1,1 +1,0 @@
-allow installd timekeep_app_data_file:dir { create_dir_perms relabelfrom relabelto };

--- a/seapp_contexts
+++ b/seapp_contexts
@@ -1,2 +1,2 @@
 #Add new domain for Timekeep
-user=system seinfo=platform name=com.sony.timekeep domain=timekeep_app type=timekeep_app_data_file
+user=system seinfo=platform name=com.sony.timekeep domain=timekeep_app type=system_data_file

--- a/system_server.te
+++ b/system_server.te
@@ -13,7 +13,6 @@ netmgr_socket(system_server);
 #Rules for system server to talk to peripheral manager
 use_per_mgr(system_server);
 
-allow system_server timekeep_app_data_file:dir r_dir_perms;
 
 r_dir_file(system_server, sysfs_addrsetup)
 r_dir_file(system_server, sysfs_socinfo)

--- a/timekeep_app.te
+++ b/timekeep_app.te
@@ -2,8 +2,6 @@ type timekeep_app, domain;
 
 app_domain(timekeep_app)
 
-allow timekeep_app timekeep_app_data_file:dir create_dir_perms;
-
 r_dir_file(timekeep_app, sysfs_timekeep)
 
 allow timekeep_app activity_service:service_manager find;


### PR DESCRIPTION
[   48.433589] init: avc:  denied  { set } for property=persist.sys.timeadjust scontext=u:r:timekeep_app:s0 tcontext=u:object_r:timekeep_prop:s0 tclass=property_service

Signed-off-by: Humberto Borba <humberos@gmail.com>