### PR TITLE
Sepolicy: avoid bluetooth denials

### DIFF
--- a/bluetooth.te
+++ b/bluetooth.te
@@ -2,3 +2,5 @@ allow bluetooth sysfs:file w_file_perms;
 
 # Allow MAC address file reading
 r_dir_file(bluetooth, addrsetup_data_file)
+
+allow bluetooth smd_device:chr_file rw_file_perms;


### PR DESCRIPTION
[ 6780.196291] type=1400 audit(1465692088.613:384): avc: denied { read write } for pid=12576 comm=hci_thread name=smd3 dev=tmpfs ino=9282 scontext=u:r:bluetooth:s0 tcontext=u:object_r:smd_device:s0 tclass=chr_file permissive=1

[ 6780.198091] type=1400 audit(1465692088.613:385): avc: denied { open } for pid=12576 comm=hci_thread path=/dev/smd3 dev=tmpfs ino=9282 scontext=u:r:bluetooth:s0 tcontext=u:object_r:smd_device:s0 tclass=chr_file permissive=1

[ 6780.205844] type=1400 audit(1465692088.623:386): avc: denied { ioctl } for pid=12576 comm=hci_thread path=/dev/smd3 dev=tmpfs ino=9282 ioctlcmd=540b scontext=u:r:bluetooth:s0 tcontext=u:object_r:smd_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>