### PR TITLE
Fix platform_app denials

### DIFF
--- a/platform_app.te
+++ b/platform_app.te
@@ -1,0 +1,3 @@
+# Allow NFC service to be found
+allow platform_app nfc_service:service_manager find;
+


### PR DESCRIPTION
Allow NFC service to be found

avc:  denied  { find } for service=nfc scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:nfc_service:s0 tclass=service_manager
E NFC     : could not retrieve NFC service

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I7cb653c80dd752a0965c5e36c6d9aad3149f95f1