### PR TITLE
Sepolicy: avoid rild denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -197,7 +197,7 @@
 
 # WiFi MAC address
 /sys/devices/fb000000\.qcom,wcnss-wlan/wcnss_mac_addr                                    u:object_r:sysfs_addrsetup:s0
-/sys/devices/fb21b000.qcom,pronto/subsys2/name                                           u:object_r:sysfs_pronto:s0
+/sys/devices/fb21b000\.qcom,pronto/subsys2/name                                          u:object_r:sysfs_pronto:s0
 
 ###################################
 # data files

--- a/rild.te
+++ b/rild.te
@@ -11,5 +11,7 @@ netmgr_socket(rild);
 # Rule for RILD to talk to peripheral manager
 use_per_mgr(rild);
 
+allow rild sysfs_pronto:file r_file_perms;
+
 r_dir_file(rild, sysfs_socinfo)
 r_dir_file(rild, sysfs_subsys)


### PR DESCRIPTION
06-15 01:06:33.979 I/rild    (  395): type=1400 audit(0.0:18): avc: denied { read } for name="name" dev="sysfs" ino=18168 scontext=u:r:rild:s0 tcontext=u:object_r:sysfs_pronto:s0 tclass=file permissive=1

06-15 01:06:33.979 I/rild    (  395): type=1400 audit(0.0:19): avc: denied { open } for path="/sys/devices/fb21b000.qcom,pronto/subsys2/name" dev="sysfs" ino=18168 scontext=u:r:rild:s0 tcontext=u:object_r:sysfs_pronto:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>