### PR TITLE
Sepolicy: avoid bluetooth denials

### DIFF
--- a/bluetooth.te
+++ b/bluetooth.te
@@ -2,3 +2,5 @@ allow bluetooth sysfs:file w_file_perms;
 
 # Allow MAC address file reading
 r_dir_file(bluetooth, addrsetup_data_file)
+
+allow bluetooth smd_device:chr_file rw_file_perms;


### PR DESCRIPTION
06-15 01:40:00.809 I/hci_thread( 5639): type=1400 audit(0.0:23): avc: denied { read write } for name="smd3" dev="tmpfs" ino=4953 scontext=u:r:bluetooth:s0 tcontext=u:object_r:smd_device:s0 tclass=chr_file permissive=1

06-15 01:40:00.809 I/hci_thread( 5639): type=1400 audit(0.0:24): avc: denied { open } for path="/dev/smd3" dev="tmpfs" ino=4953 scontext=u:r:bluetooth:s0 tcontext=u:object_r:smd_device:s0 tclass=chr_file permissive=1

06-15 01:40:00.809 I/hci_thread( 5639): type=1400 audit(0.0:25): avc: denied { ioctl } for path="/dev/smd3" dev="tmpfs" ino=4953 ioctlcmd=540b scontext=u:r:bluetooth:s0 tcontext=u:object_r:smd_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>