### PR TITLE
sony: sepolicy: Fix touchfusion denied

### DIFF
--- a/touchfusion.te
+++ b/touchfusion.te
@@ -7,6 +7,8 @@ domain_auto_trans(kernel, touchfusion_exec, touchfusion);
 allow touchfusion self:capability { setgid setuid sys_nice net_admin };
 allow touchfusion self:netlink_socket create_socket_perms;
 
+allow touchfusion device:dir rw_dir_perms;
+
 allow touchfusion cgroup:dir { create add_name };
 
 allow touchfusion graphics_device:chr_file rw_file_perms;


### PR DESCRIPTION
It is required for kernel@1.3.3

avc:  denied  { write } for  pid=452 comm="touch_fusion"
name="/" dev="tmpfs" ino=14122 scontext=u:r:touchfusion:s0
tcontext=u:object_r:device:s0 tclass=dir permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Id9741699e1da2ba1e63c1240458ab6e4bc68320b