### PR TITLE
Fix some minor denials from honami

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -176,12 +176,14 @@
 # Subsystem
 /sys/devices(/soc\.0)?/fe200000\.qcom,lpass/subsys1/name                                 u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0)?/fc880000\.qcom,mss/subsys2/name                                   u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0)?/fc880000\.qcom,mss/subsys3/name                                   u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0)?/fdce0000\.qcom,venus/subsys0/name                                 u:object_r:sysfs_subsys:s0
 
 # Thermal
 /sys/devices(/soc\.0)?/02-qcom,qpnp-smbcharger/power_supply/battery/charging_enabled     u:object_r:sysfs_thermal:s0
 /sys/devices(/soc\.0)?/02-qcom,qpnp-smbcharger/power_supply/battery/system_temp_level    u:object_r:sysfs_thermal:s0
 /sys/devices(/soc\.0)?/f9200000\.ssusb/power_supply/usb/current_max                      u:object_r:sysfs_thermal:s0
+/sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpuclk                      u:object_r:sysfs_thermal:s0
 /sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/max_gpuclk                  u:object_r:sysfs_thermal:s0
 
 # Timekeep

--- a/netmgrd.te
+++ b/netmgrd.te
@@ -53,6 +53,7 @@ allow netmgrd shell_exec:file rx_file_perms;
 wakelock_use(netmgrd)
 
 r_dir_file(netmgrd, sysfs)
+r_dir_file(netmgrd, sysfs_pronto)
 r_dir_file(netmgrd, sysfs_socinfo)
 r_dir_file(netmgrd, sysfs_subsys)
 

--- a/sensors.te
+++ b/sensors.te
@@ -48,5 +48,7 @@ binder_call(sensors, per_mgr)
 #Rules for sensors to talk to peripheral manager
 use_per_mgr(sensors);
 
+r_dir_file(sensors, sysfs_pronto)
 r_dir_file(sensors, sysfs_socinfo)
+r_dir_file(sensors, sysfs_subsys)
 r_dir_file(sensors, system_file)

--- a/system_server.te
+++ b/system_server.te
@@ -16,5 +16,6 @@ use_per_mgr(system_server);
 allow system_server timekeep_app_data_file:dir r_dir_perms;
 
 r_dir_file(system_server, sysfs_addrsetup)
+r_dir_file(system_server, sysfs_pronto)
 r_dir_file(system_server, sysfs_socinfo)
 r_dir_file(system_server, sysfs_subsys)


### PR DESCRIPTION
Add extra subsys, thermal, and pronto sysfs and grant access to them

Signed-off-by: Adam Farden <adam@farden.cz>