### PR TITLE
sepolicy: avoid rild denials

### DIFF
--- a/rild.te
+++ b/rild.te
@@ -12,6 +12,7 @@ netmgr_socket(rild);
 use_per_mgr(rild);
 
 allow rild sysfs_pronto:file r_file_perms;
+allow rild mediaserver_service:service_manager find;
 
 r_dir_file(rild, sysfs_socinfo)
 r_dir_file(rild, sysfs_subsys)


### PR DESCRIPTION
06-22 10:19:02.305 E/SELinux (  325): avc:  denied  { find } for service=media.audio_flinger pid=363 uid=1001 scontext=u:r:rild:s0 tcontext=u:object_r:mediaserver_service:s0 tclass=service_manager permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>