### PR TITLE
sepolicy: avoid lowmemorykiller denials

### DIFF
--- a/lmkd.te
+++ b/lmkd.te
@@ -1,0 +1,1 @@
+allow lmkd sysfs_lowmemorykiller:dir search;


### PR DESCRIPTION
06-22 10:18:20.069 I/lmkd    (  324): type=1400 audit(0.0:7): avc: denied { search } for name=lowmemorykiller dev=sysfs ino=6510 scontext=u:r:lmkd:s0 tcontext=u:object_r:sysfs_lowmemorykiller:s0 tclass=dir permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>