### PR TITLE
Add required rild sepolicy rules.

### DIFF
--- a/rild.te
+++ b/rild.te
@@ -1,5 +1,9 @@
-qmux_socket(rild);
+binder_call(rild, mediaserver)
 binder_use(rild)
+binder_service(rild)
+
+qmux_socket(rild);
+
 
 r_dir_file(rild, sysfs_ssr)
 
@@ -16,3 +20,4 @@ allow rild mediaserver_service:service_manager find;
 
 r_dir_file(rild, sysfs_socinfo)
 r_dir_file(rild, sysfs_subsys)
+


### PR DESCRIPTION
These modifications enable sony users to make and receive calls. Without them it is impossible to end an
initiated call and receiving calls results in "SIM not found".

Already made a couple of calls with these modifications.

Change-Id: I5d4e70e3c516ded6c3df03f9ad4a20debb0fbd6c