### PR TITLE
sepolicy: remove double selinux definitions

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -68,10 +68,6 @@
 /dev/block/platform/msm_sdcc\.1/by-name/TA                     u:object_r:trim_area_partition_device:s0
 /dev/block/bootdevice/by-name/TA                               u:object_r:trim_area_partition_device:s0
 
-/dev/block/platform/soc.0/f9824900.sdhci/by-name/FOTAKernel    u:object_r:recovery_block_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/FOTAKernel             u:object_r:recovery_block_device:s0
-/dev/block/bootdevice/by-name/FOTAKernel                       u:object_r:recovery_block_device:s0
-
 /dev/block/platform/soc.0/f9824900.sdhci/by-name/userdata      u:object_r:userdata_block_device:s0
 /dev/block/platform/msm_sdcc\.1/by-name/userdata               u:object_r:userdata_block_device:s0
 /dev/block/bootdevice/by-name/userdata                         u:object_r:userdata_block_device:s0


### PR DESCRIPTION
It is causing multiple same definitions