### PR TITLE
Revert "sepolicy: fix recovery path for SELinux"

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -80,9 +80,9 @@
 /dev/block/platform/msm_sdcc\.1/by-name/boot                   u:object_r:boot_block_device:s0
 /dev/block/bootdevice/by-name/boot                             u:object_r:boot_block_device:s0
 
-/dev/block/platform/soc.0/f9824900.sdhci/by-name/FOTAKernel    u:object_r:recovery_block_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/FOTAKernel             u:object_r:recovery_block_device:s0
-/dev/block/bootdevice/by-name/FOTAKernel                       u:object_r:recovery_block_device:s0
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/recovery      u:object_r:recovery_block_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/recovery               u:object_r:recovery_block_device:s0
+/dev/block/bootdevice/by-name/recovery                         u:object_r:recovery_block_device:s0
 
 /dev/block/platform/soc.0/f9824900.sdhci/by-name/cache         u:object_r:cache_block_device:s0
 /dev/block/platform/msm_sdcc\.1/by-name/cache                  u:object_r:cache_block_device:s0


### PR DESCRIPTION
This reverts commit 12a3ef3d3078c48e4ea6d48b9e1fd118bc016181.

FOTAKernel is already defined here;
https://github.com/sonyxperiadev/device-sony-sepolicy/blob/master/file_contexts#L71