### PR TITLE
Sepolicy: Let camera work on User builds

### DIFF
--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -4,11 +4,9 @@ type mm-qcamerad_exec, exec_type, file_type;
 init_daemon_domain(mm-qcamerad)
 
 #added to support EZTune for camera
-userdebug_or_eng(`
   allow mm-qcamerad camera_data_file:file create_file_perms;
   allow mm-qcamerad self:tcp_socket create_stream_socket_perms;
   allow mm-qcamerad node:tcp_socket node_bind;
-')
 
 #Communicate with user land process through domain socket
 allow mm-qcamerad camera_socket:sock_file { create unlink write };


### PR DESCRIPTION
Rules are required for our Camera HAL so enabled for all types of build.