### PR TITLE
[m-mr1] sony: sepolicy: Address touchfusion denial

### DIFF
--- a/touchfusion.te
+++ b/touchfusion.te
@@ -8,6 +8,7 @@ allow touchfusion self:capability { setgid setuid sys_nice net_admin };
 allow touchfusion self:netlink_socket create_socket_perms;
 
 allow touchfusion device:dir rw_dir_perms;
+allow touchfusion device:file create_file_perms;
 
 allow touchfusion cgroup:dir { create add_name };
 


### PR DESCRIPTION
[   15.725492] type=1400 audit(25036419.049:4): avc:  denied
{ create } for  pid=421 comm="touch_fusion" name="kmsg"
scontext=u:r:touchfusion:s0 tcontext=u:object_r:device:s0
tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ic6d1edbb65f6f7ae2e58641a70a4c22d271f53e7