### PR TITLE
[m-mr1] sony: sepolicy: Fix kernel, init and ueventd denials

### DIFF
--- a/init.te
+++ b/init.te
@@ -1,5 +1,9 @@
 #For sdcard
 allow init tmpfs:lnk_file create_file_perms;
+allow init tmpfs:file create_file_perms;
+allow init tmpfs:dir create_dir_perms;
+
+allow init self:process { setcurrent };
 
 allow init proc_kernel_sched:file write;
 

--- a/kernel.te
+++ b/kernel.te
@@ -1,10 +1,18 @@
-allow kernel tmpfs:file rw_file_perms;
+allow kernel tmpfs:file create_file_perms;
+allow kernel tmpfs:dir create_dir_perms;
 allow kernel rootfs:file rx_file_perms;
 allow kernel block_device:blk_file rw_file_perms;
 
 userdebug_or_eng(`
-  allow kernel self:capability { dac_read_search dac_override net_admin };
+  allow kernel self:capability { 
+    dac_read_search
+    dac_override
+    net_admin
+    setgid
+    setuid
+  };
   allow kernel self:socket create_socket_perms;
+  allow kernel self:netlink_socket create_socket_perms;
 ')
 
 # Access firmware_file

--- a/ueventd.te
+++ b/ueventd.te
@@ -13,3 +13,6 @@ allow ueventd {
     sysfs_usb_supply
     sysfs_socinfo
 }:file w_file_perms;
+
+allow ueventd tmpfs:file create_file_perms;
+allow ueventd tmpfs:dir create_dir_perms;


### PR DESCRIPTION
this patch is required mainly for touchfusion.

avc:  denied  { write } for  pid=381 comm="touch_fusion"
name="/" dev="tmpfs" ino=297 scontext=u:r:kernel:s0
tcontext=u:object_r:tmpfs:s0 tclass=dir permissive=0

avc:  denied  { create } for  pid=371 comm="touch_fusion"
name="kmsg" scontext=u:r:kernel:s0
tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0

avc:  denied  { create } for  pid=382 comm="touch_fusion"
scontext=u:r:kernel:s0 tcontext=u:r:kernel:s0
tclass=netlink_socket permissive=0

avc:  denied  { write } for  pid=378 comm="init" name="kmsg"
dev="tmpfs" ino=1032 scontext=u:r:init:s0
tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0

avc:  denied  { write } for  pid=378 comm="init" name="kmsg"
dev="tmpfs" ino=1032 scontext=u:r:init:s0
tcontext=u:object_r:tmpfs:s0 tclass=dir permissive=0

avc:  denied  { setcurrent } for  pid=378 comm="init"
scontext=u:r:init:s0 tcontext=u:r:init:s0
tclass=process permissive=0

avc:  denied  { write } for  pid=381 comm="ueventd"
name="kmsg" dev="tmpfs" ino=1032 scontext=u:r:ueventd:s0
tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0

avc:  denied  { write } for  pid=381 comm="ueventd"
name="kmsg" dev="tmpfs" ino=1032 scontext=u:r:ueventd:s0
tcontext=u:object_r:tmpfs:s0 tclass=dir permissive=0

avc:  denied  { setgid } for  pid=378 comm="touch_fusion"
capability=6  scontext=u:r:kernel:s0
tcontext=u:r:kernel:s0 tclass=capability permissive=0

avc:  denied  { setuid } for  pid=381 comm="touch_fusion"
capability=7  scontext=u:r:kernel:s0
tcontext=u:r:kernel:s0 tclass=capability permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I82c75fd4059c6e543c9b51a28d28905e578fd97d