### PR TITLE
[m-mr1] sony: sepolicy: Address denial for logd

### DIFF
--- a/logd.te
+++ b/logd.te
@@ -1,0 +1,1 @@
+allow logd device:file rw_file_perms;


### PR DESCRIPTION
[   18.344641] type=1400 audit(25122845.559:4):
avc:  denied  { write } for  pid=455 comm="logd"
name="kmsg" dev="tmpfs" ino=13404 scontext=u:r:logd:s0
tcontext=u:object_r:device:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I5834f0cc206504401e102704b1213a322cbd0521