### PR TITLE
[m-mr1] sony: sepolicy: Address denial for zygote

### DIFF
--- a/zygote.te
+++ b/zygote.te
@@ -1,0 +1,1 @@
+allow zygote device:file rw_file_perms;


### PR DESCRIPTION
[   7.3231] type=1400 audit(0.0:24):
avc: denied { open } for path="/dev/urandom"
dev="tmpfs" ino=250 scontext=u:r:zygote:s0
tcontext=u:object_r:device:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I14cb36e3f15136233f01b30ede9e34ab199fc3f3