### PR TITLE
sepolicy: avoid system_server denials

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -14,7 +14,7 @@ netmgr_socket(system_server);
 use_per_mgr(system_server);
 
 allow system_server system_app_data_file:dir r_dir_perms;
-
+allow system_server system_server:unix_stream_socket ioctl;
 allow system_server sysfs_pronto:file r_file_perms;
 
 r_dir_file(system_server, sysfs_addrsetup)


### PR DESCRIPTION
07-08 09:15:15.089: I/system_server(914): type=1400 audit(0.0:28): avc: denied { ioctl } for path=socket:[19688] dev=sockfs ino=19688 ioctlcmd=7704 scontext=u:r:system_server:s0 tcontext=u:r:system_server:s0 tclass=unix_stream_socket permissive=1
07-08 09:15:15.089: I/system_server(914): type=1400 audit(0.0:29): avc: denied { ioctl } for path=socket:[19688] dev=sockfs ino=19688 ioctlcmd=7704 scontext=u:r:system_server:s0 tcontext=u:r:system_server:s0 tclass=unix_stream_socket permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>