### PR TITLE
sepolicy: avoid debuggerd denials

### DIFF
--- a/debuggerd.te
+++ b/debuggerd.te
@@ -1,0 +1,1 @@
+allow debuggerd gpu_device:chr_file { read open getattr };


### PR DESCRIPTION
[ 1546.909952] type=1400 audit(1468395418.843:745): avc: denied { read } for pid=400 comm=debuggerd name=kgsl-3d0 dev=tmpfs ino=8315 scontext=u:r:debuggerd:s0 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=1

[ 1546.910464] type=1400 audit(1468395418.843:746): avc: denied { open } for pid=400 comm=debuggerd path=/dev/kgsl-3d0 dev=tmpfs ino=8315 scontext=u:r:debuggerd:s0 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=1

[ 1546.910929] type=1400 audit(1468395418.843:747): avc: denied { getattr } for pid=400 comm=debuggerd path=/dev/kgsl-3d0 dev=tmpfs ino=8315 scontext=u:r:debuggerd:s0 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>