### PR TITLE
sony: sepolicy: Fix kernel denial

### DIFF
--- a/kernel.te
+++ b/kernel.te
@@ -1,3 +1,4 @@
+allow kernel device:dir create_dir_perms;
 allow kernel tmpfs:file create_file_perms;
 allow kernel tmpfs:dir create_dir_perms;
 allow kernel rootfs:file rx_file_perms;


### PR DESCRIPTION
One more touchfusion requirement.

<5>[   10.766743] type=1400 audit(25499759.889:4):
avc:  denied  { write } for  pid=368 comm="touch_fusion" name="/"
dev="tmpfs" ino=12435 scontext=u:r:kernel:s0
tcontext=u:object_r:device:s0 tclass=dir permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Iabf60483453b69d15ebbe238093051f12a29f7e7