### PR TITLE
sony: sepolicy: Address denials for ioctl rules

### DIFF
--- a/surfaceflinger.te
+++ b/surfaceflinger.te
@@ -1,1 +1,3 @@
 rw_dir_file(surfaceflinger, sysfs_graphics)
+
+allow surfaceflinger self:unix_stream_socket 0x7704;

--- a/system_server.te
+++ b/system_server.te
@@ -14,7 +14,7 @@ netmgr_socket(system_server);
 use_per_mgr(system_server);
 
 allow system_server system_app_data_file:dir r_dir_perms;
-allow system_server system_server:unix_stream_socket ioctl;
+allow system_server self:unix_stream_socket 0x7704;
 allow system_server sysfs_pronto:file r_file_perms;
 
 r_dir_file(system_server, sysfs_addrsetup)


### PR DESCRIPTION
This is required after latest aosp security update.

[   40.519101] type=1400 audit(1468462596.535:36):
avc: denied { ioctl } for pid=508 comm="Binder_2"
path="socket:[26176]" dev="sockfs" ino=26176
ioctlcmd=7704 scontext=u:r:surfaceflinger:s0
tcontext=u:r:surfaceflinger:s0
tclass=unix_stream_socket permissive=0

[   41.273510] type=1400 audit(1468462597.295:37):
avc: denied { ioctl } for pid=3271 comm="Binder_A"
path="socket:[27998]" dev="sockfs" ino=27998
ioctlcmd=7704 scontext=u:r:system_server:s0
tcontext=u:r:system_server:s0
tclass=unix_stream_socket permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I2fb8962cef42892c042b66dbccc7503995f49be2