### PR TITLE
sony: sepolicy: Address denial for perfprofd

### DIFF
--- a/perfprofd.te
+++ b/perfprofd.te
@@ -1,0 +1,1 @@
+allow perfprofd device:file r_file_perms;


### PR DESCRIPTION
09-01 11:55:49.877 550 550 W perfprofd: type=1400 audit(0.0:5):
avc: denied { open } for path="/dev/urandom" dev="tmpfs"
ino=307 scontext=u:r:perfprofd:s0 tcontext=u:object_r:device:s0
tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Iecfdeb481e09d6522e219c008be6d442b2c24f95