### PR TITLE
sony: sepolicy: Address denial for rild

### DIFF
--- a/rild.te
+++ b/rild.te
@@ -15,6 +15,7 @@ netmgr_socket(rild);
 # Rule for RILD to talk to peripheral manager
 use_per_mgr(rild);
 
+allow rild system_health_monitor_device:chr_file r_file_perms;
 allow rild sysfs_pronto:file r_file_perms;
 allow rild mediaserver_service:service_manager find;
 allow rild mediaserver:binder call;


### PR DESCRIPTION
[  583.100707] type=1400 audit(1468492785.389:5):
avc: denied { read } for pid=850 comm="rild"
name="system_health_monitor" dev="tmpfs"
ino=13452 scontext=u:r:rild:s0
tcontext=u:object_r:system_health_monitor_device:s0
tclass=chr_file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Iceb7571370abdcf3be3533725e42270c594a6cea