### PR TITLE
sepolicy: avoid graphics denials for cam

### DIFF
--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -30,3 +30,6 @@ allow mm-qcamerad camera_prop:file r_file_perms;
 allow mm-qcamerad ion_device:chr_file rw_file_perms;
 
 r_dir_file(mm-qcamerad, sysfs_video)
+
+# Allow access to /dev/graphics/fb* for screen capture
+allow mm-qcamerad graphics_device:chr_file rw_file_perms;


### PR DESCRIPTION
[   15.299568] type=1400 audit(1469910130.019:6): avc: denied { read } for pid=1138 comm=CAM_MctServ name=fb0 dev=tmpfs ino=9887 scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:graphics_device:s0 tclass=chr_file permissive=1

[   15.300698] type=1400 audit(1469910130.019:7): avc: denied { open } for pid=1138 comm=CAM_MctServ path=/dev/graphics/fb0 dev=tmpfs ino=9887 scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:graphics_device:s0 tclass=chr_file permissive=1

[   15.300788] type=1400 audit(1469910130.019:8): avc: denied { ioctl } for pid=1138 comm=CAM_MctServ path=/dev/graphics/fb0 dev=tmpfs ino=9887 ioctlcmd=4600 scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:graphics_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>