### PR TITLE
sony: sepolicy: Address denials for timekeep

### DIFF
--- a/file.te
+++ b/file.te
@@ -63,6 +63,7 @@ type proc_kernel_sched, fs_type;
 
 type acdb_data_file, file_type, data_file_type;
 type addrsetup_data_file, file_type, data_file_type;
+type timekeep_data_file, file_type, data_file_type;
 
 type sysfs_addrsetup, fs_type, sysfs_type;
 type sysfs_fingerprintd_writable, fs_type, sysfs_type;

--- a/file_contexts
+++ b/file_contexts
@@ -216,6 +216,7 @@
 /data/misc/fm(/.*)?                                                 u:object_r:fm_data_file:s0
 /data/audio/acdbdata(/.*)?                                          u:object_r:acdb_data_file:s0
 /data/etc(/.*)?                                                     u:object_r:addrsetup_data_file:s0
+/data/time(/.*)?                                                    u:object_r:timekeep_data_file:s0
 
 ###################################
 # persist files

--- a/system_app.te
+++ b/system_app.te
@@ -7,3 +7,5 @@ allow system_app activity_service:service_manager find;
 allow system_app connectivity_service:service_manager find;
 allow system_app display_service:service_manager find;
 allow system_app network_management_service:service_manager find;
+allow system_app timekeep_data_file:dir { create_dir_perms search };
+allow system_app timekeep_data_file:file create_file_perms;

--- a/timekeep.te
+++ b/timekeep.te
@@ -4,7 +4,16 @@ type timekeep_exec, exec_type, file_type;
 # Started by init
 init_daemon_domain(timekeep)
 
-allow timekeep self:capability sys_time;
+allow timekeep self:capability {
+    fowner
+    fsetid
+    sys_time
+    dac_override
+    dac_read_search
+};
+
+allow timekeep timekeep_data_file:file create_file_perms;
+allow timekeep timekeep_data_file:dir { create_dir_perms search };
 
 set_prop(timekeep, timekeep_prop)
 


### PR DESCRIPTION
sony: sepolicy: Fix timekeep denials

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I80b55ad8bb60a105dac9b7d348e47a694fcaa821

sony: sepolicy: Address denials for timekeep

avc: denied { fowner } for pid=444 comm="timekeep" capability=3
scontext=u:r:timekeep:s0 tcontext=u:r:timekeep:s0 tclass=capability permissive=0

avc: denied { fsetid } for capability=4 scontext=u:r:timekeep:s0
tcontext=u:r:timekeep:s0 tclass=capability permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ie6c7af67a960b3c44b2678a17747fa18bbf1d2b8