### PR TITLE
sepolicy: avoid cam denials

### DIFF
--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -4,6 +4,7 @@ type mm-qcamerad_exec, exec_type, file_type;
 init_daemon_domain(mm-qcamerad)
 
 #added to support EZTune for camera
+  allow mm-qcamerad debugfs:file r_file_perms;
   allow mm-qcamerad camera_data_file:file create_file_perms;
   allow mm-qcamerad self:tcp_socket create_stream_socket_perms;
   allow mm-qcamerad node:tcp_socket node_bind;


### PR DESCRIPTION
08-20 19:06:24.976  2181  2181 I CAM_mct_freeze: type=1400 audit(0.0:56): avc: denied { read } for name=enable dev=debugfs ino=9635 scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:debugfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>