### PR TITLE
sepolicy: avoid bluetooth denials

### DIFF
--- a/bluetooth.te
+++ b/bluetooth.te
@@ -4,3 +4,4 @@ allow bluetooth sysfs:file w_file_perms;
 r_dir_file(bluetooth, addrsetup_data_file)
 
 allow bluetooth smd_device:chr_file rw_file_perms;
+allow bluetooth bluetooth_prop:property_service set;

--- a/property_contexts
+++ b/property_contexts
@@ -5,3 +5,5 @@ debug.sf.nobootanimation   u:object_r:boot_animation_prop:s0
 sys.keymaster.loaded       u:object_r:tee_prop:s0
 sys.listeners.registered   u:object_r:tee_prop:s0
 persist.sys.timeadjust     u:object_r:timekeep_prop:s0
+
+bluetooth.status           u:object_r:bluetooth_prop:s0


### PR DESCRIPTION
[   37.524639] init: avc:  denied  { set } for property=bluetooth.status scontext=u:r:toolbox:s0 tcontext=u:object_r:bluetooth_prop:s0 tclass=property_service

Signed-off-by: David Viteri <davidteri91@gmail.com>