### PR TITLE
sepolicy: add init_shell.te needed for bluetooth

### DIFF
--- a/init_shell.te
+++ b/init_shell.te
@@ -1,0 +1,7 @@
+# Restricted domain for shell processes spawned by init.
+# Normally these are shell commands or scripts invoked via sh
+# from an init*.rc file.  No service should ever run in this domain.
+type qti_init_shell, domain;
+domain_auto_trans(init, shell_exec, qti_init_shell)
+
+allow qti_init_shell bluetooth_prop:property_service set;


### PR DESCRIPTION
needed by: ee1a33bfc8f76c6aa22e6751cd5f61e6e378a969

also fixes some denials like:

08-18 16:32:45.186  4605  4605 I init    : type=1400 audit(0.0:12): avc: denied { execute_no_trans } for path="/system/bin/sh" dev="mmcblk0p23" ino=423 scontext=u:r:init:s0 tcontext=u:object_r:shell_exec:s0 tclass=file permissive=1
08-18 16:32:45.196  4606  4606 I getprop : type=1400 audit(0.0:13): avc: denied { write } for path="pipe:[33984]" dev="pipefs" ino=33984 scontext=u:r:toolbox:s0 tcontext=u:r:init:s0 tclass=fifo_file permissive=1
08-18 16:32:45.216  4606  4606 I getprop : type=1400 audit(0.0:14): avc: denied { getattr } for path="pipe:[33984]" dev="pipefs" ino=33984 scontext=u:r:toolbox:s0 tcontext=u:r:init:s0 tclass=fifo_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>