### PR TITLE
sepolicy: avoid selinux denials

### DIFF
--- a/cameraserver.te
+++ b/cameraserver.te
@@ -1,0 +1,1 @@
+allow cameraserver gpu_device:chr_file rw_file_perms;


### PR DESCRIPTION
01-01 00:58:18.999 19097 19097 I cameraserver: type=1400 audit(0.0:517): avc: denied { read write } for name=kgsl-3d0 dev=tmpfs ino=612 scontext=u:r:cameraserver:s0 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=1
01-01 00:58:18.999 19097 19097 I cameraserver: type=1400 audit(0.0:518): avc: denied { open } for path=/dev/kgsl-3d0 dev=tmpfs ino=612 scontext=u:r:cameraserver:s0 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=1
01-01 00:58:18.999 19097 19097 I cameraserver: type=1400 audit(0.0:519): avc: denied { ioctl } for path=/dev/kgsl-3d0 dev=tmpfs ino=612 ioctlcmd=902 scontext=u:r:cameraserver:s0 tcontext=u:object_r:gpu_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>