### PR TITLE
sepolicy: avoid Google Cam denials

### DIFF
--- a/untrusted_app.te
+++ b/untrusted_app.te
@@ -1,0 +1,2 @@
+# Google Camera
+allow untrusted_app camera_prop:file r_file_perms;


### PR DESCRIPTION
08-27 17:45:06.774  3966  3966 I Executor-4: type=1400 audit(0.0:5): avc: denied { open } for path=/dev/__properties__/u:object_r:camera_prop:s0 dev=tmpfs ino=10858 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:camera_prop:s0 tclass=file permissive=1
08-27 17:45:06.774  3966  3966 I Executor-4: type=1400 audit(0.0:6): avc: denied { getattr } for path=/dev/__properties__/u:object_r:camera_prop:s0 dev=tmpfs ino=10858 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:camera_prop:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>