### PR TITLE
sepolicy: avoid rild denials

### DIFF
--- a/rild.te
+++ b/rild.te
@@ -17,6 +17,7 @@ use_per_mgr(rild);
 
 allow rild sysfs_pronto:file r_file_perms;
 allow rild mediaserver_service:service_manager find;
+allow rild system_health_monitor_device:chr_file r_file_perms;
 
 r_dir_file(rild, sysfs_socinfo)
 r_dir_file(rild, sysfs_subsys)


### PR DESCRIPTION
[   75.554828] type=1400 audit(1472503423.259:4): avc: denied { read } for pid=3953 comm=rild name=system_health_monitor dev=tmpfs ino=13958 scontext=u:r:rild:s0 tcontext=u:object_r:system_health_monitor_device:s0 tclass=chr_file permissive=1
[   75.559338] type=1400 audit(1472503423.259:5): avc: denied { open } for pid=3953 comm=rild path=/dev/system_health_monitor dev=tmpfs ino=13958 scontext=u:r:rild:s0 tcontext=u:object_r:system_health_monitor_device:s0 tclass=chr_file permissive=1
[   75.559469] type=1400 audit(1472503423.259:6): avc: denied { ioctl } for pid=3953 comm=rild path=/dev/system_health_monitor dev=tmpfs ino=13958 ioctlcmd=c300 scontext=u:r:rild:s0 tcontext=u:object_r:system_health_monitor_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>