### PR TITLE
sony: sepolicy: Address radio denied

### DIFF
--- a/radio.te
+++ b/radio.te
@@ -1,0 +1,1 @@
+allow radio system_app_data_file:dir getattr;


### PR DESCRIPTION
09-09 14:35:17.827  2503  2503 I m.android.phone: type=1400 audit(0.0:10):
avc: denied { getattr } for path="/data/user_de/0/com.android.settings"
dev="mmcblk0p43" ino=457945 scontext=u:r:radio:s0
tcontext=u:object_r:system_app_data_file:s0 tclass=dir permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I40380fdeb1cd7646ec75d348ad0a575dd176d0b9