### PR TITLE
Allow recovery to use the misc partition and read the syslog

### DIFF
--- a/recovery.te
+++ b/recovery.te
@@ -1,0 +1,2 @@
+# Recovery needs access to syslog
+allow recovery self:capability2 syslog;

--- a/uncrypt.te
+++ b/uncrypt.te
@@ -1,0 +1,2 @@
+# Allow recovery to read the misc partition
+allow uncrypt misc_partition:blk_file rw_file_perms;


### PR DESCRIPTION
Android Nougat changed how it communicates with the recovery
partition. Until now the recovery commands had been written
to the /cache partition, but this has changed. Now recovery
writes to the /misc partition.

Fortunately for kitakami devices and beyond we actually have
an empty and unused /misc partition we can use. For older
devices we'll need to be creative.

Signed-off-by: Adam Farden <adam@farden.cz>