### PR TITLE
[master] sony: sepolicy: Address kernel denied

### DIFF
--- a/kernel.te
+++ b/kernel.te
@@ -5,6 +5,8 @@ allow kernel rootfs:file rx_file_perms;
 allow kernel block_device:blk_file rw_file_perms;
 allow kernel touchfusion_exec:file relabelto;
 
+allow kernel self:socket create;
+
 domain_auto_trans(kernel, touchfusion_exec, touchfusion)
 
 # Access firmware_file


### PR DESCRIPTION
[   16.658265] type=1400 audit(1474049901.859:8): avc: denied { create }
for pid=51 comm="kworker/u12:2" scontext=u:r:kernel:s0
tcontext=u:r:kernel:s0 tclass=socket permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>