### PR TITLE
[master] sony: sepolicy: Address netmgrd denials

### DIFF
--- a/netmgrd.te
+++ b/netmgrd.te
@@ -52,7 +52,7 @@ allow netmgrd shell_exec:file rx_file_perms;
 #Allow netmgrd to use wakelock
 wakelock_use(netmgrd)
 
-r_dir_file(netmgrd, sysfs)
+rw_dir_file(netmgrd, sysfs)
 r_dir_file(netmgrd, sysfs_pronto)
 r_dir_file(netmgrd, sysfs_socinfo)
 r_dir_file(netmgrd, sysfs_subsys)


### PR DESCRIPTION
[   19.874101] type=1400 audit(1474049905.079:9): avc: denied { write }
for pid=1034 comm="sh" name="rps_cpus" dev="sysfs"
ino=21845 scontext=u:r:netmgrd:s0 tcontext=u:object_r:sysfs:s0
tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>