### PR TITLE
[master] sony: sepolicy: Address audioserver denials

### DIFF
--- a/audioserver.te
+++ b/audioserver.te
@@ -1,0 +1,1 @@
+r_dir_file(audioserver, sysfs)


### PR DESCRIPTION
[   16.633004] type=1400 audit(1474049901.839:3): avc: denied { read }
for pid=460 comm="audioserver" name="class" dev="sysfs" ino=10
scontext=u:r:audioserver:s0 tcontext=u:object_r:sysfs:s0
tclass=dir permissive=0

[   16.633120] type=1400 audit(1474049901.839:4): avc: denied { open }
for pid=460 comm="audioserver" path="/sys/class" dev="sysfs"
ino=10 scontext=u:r:audioserver:s0 tcontext=u:object_r:sysfs:s0
tclass=dir permissive=0

[   16.635582] type=1400 audit(1474049901.839:5): avc: denied { read }
for pid=460 comm="audioserver" name="type" dev="sysfs" ino=23402
scontext=u:r:audioserver:s0 tcontext=u:object_r:sysfs:s0
tclass=file permissive=0

[   16.639400] type=1400 audit(1474049901.839:6): avc: denied { read open }
for pid=460 comm="audioserver"
path="/sys/devices/virtual/thermal/thermal_zone22/type"
dev="sysfs" ino=23402 scontext=u:r:audioserver:s0
tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

[   16.642836] type=1400 audit(1474049901.839:7): avc: denied { getattr }
for pid=460 comm="audioserver"
path="/sys/devices/virtual/thermal/thermal_zone22/type"
dev="sysfs" ino=23402 scontext=u:r:audioserver:s0
tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>