### PR TITLE
[master] sony: sepolicy: Address tad denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -41,7 +41,6 @@
 # Dev block nodes
 #
 /dev/block/mmcblk0                                             u:object_r:root_block_device:s0
-/dev/block/mmcblk0p1                                           u:object_r:tad_block_device:s0
 /dev/block/mmcblk0rpmb                                         u:object_r:rpmb_device:s0
 
 /dev/block/platform/soc\.0/7824900\.sdhci/by-name/modemst1     u:object_r:modem_efs_partition_device:s0
@@ -69,6 +68,7 @@
 /dev/block/platform/msm_sdcc\.1/by-name/misc                   u:object_r:misc_partition:s0
 /dev/block/bootdevice/by-name/misc                             u:object_r:misc_partition:s0
 
+/dev/block/mmcblk0p1                                           u:object_r:trim_area_partition_device:s0
 /dev/block/platform/soc\.0/7824900\.sdhci/by-name/TA           u:object_r:trim_area_partition_device:s0
 /dev/block/platform/soc\.0/f9824900\.sdhci/by-name/TA          u:object_r:trim_area_partition_device:s0
 /dev/block/platform/msm_sdcc\.1/by-name/TA                     u:object_r:trim_area_partition_device:s0

--- a/tad.te
+++ b/tad.te
@@ -1,6 +1,5 @@
 type tad, domain;
 type tad_exec, exec_type, file_type;
-type tad_block_device, dev_type;
 
 # Started by init
 init_daemon_domain(tad)
@@ -9,4 +8,5 @@ init_daemon_domain(tad)
 allow tad proc:file r_file_perms;
 
 # Allow tad to work it's magic
-allow tad tad_block_device:blk_file rw_file_perms;
+allow tad trim_area_partition_device:blk_file rw_file_perms;
+allow tad block_device:dir search;


### PR DESCRIPTION
rework tad configuration

use trim_area_partition_device instead of tad_block_device
and set RW permissions to its block devices.

Fix:

tad : Trim Area daemon starting.
tad : Using trim area info (0,16) from arguments.
tad : Failed to open /dev/block/bootdevice/by-name/TA (Permission denied)
tad : Failed to configure TA library.

Address tad denials for common block devices operation (search):

tad_static: type=1400 audit(0.0:4):
avc: denied { search } for name="block" dev="tmpfs" ino=14444
scontext=u:r:tad:s0 tcontext=u:object_r:block_device:s0
tclass=dir permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I6775680d815202a958a1fff9b1e4b237f50b93e5