### PR TITLE
[master] sony: sepolicy: Address gatekeeperd denials

### DIFF
--- a/gatekeeperd.te
+++ b/gatekeeperd.te
@@ -1,2 +1,3 @@
 allow gatekeeperd firmware_file:file r_file_perms;
+allow gatekeeperd firmware_file:dir search;
 set_prop(gatekeeperd, tee_prop)


### PR DESCRIPTION
gatekeeperd: type=1400 audit(0.0:6): avc: denied { search }
for name="/" dev="mmcblk0p3" ino=1 scontext=u:r:gatekeeperd:s0
tcontext=u:object_r:firmware_file:s0 tclass=dir permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Idd64a56049858af4e88f874e86acf10753b8728e