### PR TITLE
[master] sony: sepolicy: Address mm-qcamerad denials

### DIFF
--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -33,3 +33,4 @@ r_dir_file(mm-qcamerad, sysfs_video)
 
 # Allow access to /dev/graphics/fb* for screen capture
 allow mm-qcamerad graphics_device:chr_file rw_file_perms;
+allow mm-qcamerad graphics_device:dir search;


### PR DESCRIPTION
CAM_MctServ: type=1400 audit(0.0:8): avc: denied { search }
for name="graphics" dev="tmpfs" ino=14787 scontext=u:r:mm-qcamerad:s0
tcontext=u:object_r:graphics_device:s0 tclass=dir permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I9af7d5890a9f5cc0fb750fd2f25182da0701aebb