### PR TITLE
selinux: Rename adb over network com property

### DIFF
--- a/property.te
+++ b/property.te
@@ -12,4 +12,4 @@ type timekeep_prop, property_type;
 
 type sys_pad_prop, property_type;
 
-type adbtcp_prop, property_type;
+type adbtcpes_prop, property_type;

--- a/property_contexts
+++ b/property_contexts
@@ -11,4 +11,4 @@ service.pad2.control.result   u:object_r:sys_pad_prop:s0
 ril.pad.force_calib.start     u:object_r:radio_prop:s0
 ril.pad.force_calib.result    u:object_r:radio_prop:s0
 
-adb.network.port              u:object_r:adbtcp_prop:s0
+adb.network.port.es           u:object_r:adbtcpes_prop:s0

--- a/system_app.te
+++ b/system_app.te
@@ -12,5 +12,5 @@ allow system_app network_management_service:service_manager find;
 allow system_app timekeep_data_file:dir { create_dir_perms search };
 allow system_app timekeep_data_file:file create_file_perms;
 
-allow system_app adbtcp_prop:property_service set;
+allow system_app adbtcpes_prop:property_service set;
 allow system_app camera_prop:property_service set;


### PR DESCRIPTION
this allows using ES alongside with the custom implementation some
custom roms use by appending an "es" to the respective code.