### PR TITLE
sepolicy: avoid BCM FM denials

### DIFF
--- a/init.te
+++ b/init.te
@@ -4,3 +4,6 @@ allow init tmpfs:lnk_file create_file_perms;
 allow init proc_kernel_sched:file write;
 
 allow init persist_file:dir mounton;
+
+#FM BCM
+allow init hci_attach_dev:chr_file rw_file_perms;


### PR DESCRIPTION
09-21 23:20:05.401   539   539 I brcm-uim-sysfs: type=1400 audit(0.0:196): avc: denied { write } for name=ttyHS0 dev=tmpfs ino=11777 scontext=u:r:init:s0 tcontext=u:object_r:hci_attach_dev:s0 tclass=chr_file permissive=1

09-21 23:20:05.411   539   539 I brcm-uim-sysfs: type=1400 audit(0.0:197): avc: denied { ioctl } for path=/dev/ttyHS0 dev=tmpfs ino=11777 ioctlcmd=540b scontext=u:r:init:s0 tcontext=u:object_r:hci_attach_dev:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>