### PR TITLE
[m-mr1][tiny version] sony: sepolicy: Address pad_controller denials

### DIFF
--- a/file.te
+++ b/file.te
@@ -77,3 +77,6 @@ type sysfs_video, fs_type, sysfs_type;
 
 type sysfs_thermal, sysfs_type, fs_type;
 type sysfs_uio, sysfs_type, fs_type;
+
+# AD7146 sysfs
+type sysfs_pad_controller, sysfs_type, fs_type;

--- a/file_contexts
+++ b/file_contexts
@@ -119,6 +119,7 @@
 /system/vendor/bin/mm-qcamera-daemon            u:object_r:mm-qcamerad_exec:s0
 /system/vendor/bin/msm_irqbalance               u:object_r:msm_irqbalanced_exec:s0
 /system/vendor/bin/netmgrd                      u:object_r:netmgrd_exec:s0
+/system/vendor/bin/pad_controller               u:object_r:pad_controller_exec:s0
 /system/vendor/bin/pm-service                   u:object_r:per_mgr_exec:s0
 /system/vendor/bin/pm-proxy                     u:object_r:per_mgr_exec:s0
 /system/vendor/bin/qmuxd                        u:object_r:qmuxd_exec:s0
@@ -158,6 +159,17 @@
 /sys/bus/msm_subsys/devices/subsys3/restart_level                   u:object_r:sysfs_ssr_toggle:s0
 /sys/bus/msm_subsys/devices/subsys4/restart_level                   u:object_r:sysfs_ssr_toggle:s0
 /sys/devices/soc0(/.*)?                                             u:object_r:sysfs_socinfo:s0
+
+# AD7146 Proximity
+/sys/devices/virtual/cap_sensor/ad7146/force_calib                  u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/obj_detect                   u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_set                      u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_num                      u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_data                     u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_offset                   u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/sw_updata                    u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/switch/ad7146_1/state                          u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/switch/ad7146_2/state                          u:object_r:sysfs_pad_controller:s0
 
 # Fingerprint
 /sys/bus/spi/devices/spi0\.1/clk_enable                                  u:object_r:sysfs_fingerprintd_writable:s0

--- a/pad_controller.te
+++ b/pad_controller.te
@@ -1,0 +1,17 @@
+type pad_controller, domain;
+type pad_controller_exec, exec_type, file_type;
+
+init_daemon_domain(pad_controller)
+
+unix_socket_connect(pad_controller, tad, tad)
+
+allow pad_controller init:unix_stream_socket { 
+    rw_socket_perms
+    connectto
+};
+
+allow pad_controller sys_pad_prop:property_service { set };
+
+allow pad_controller property_socket:sock_file write;
+
+allow pad_controller sysfs_pad_controller:file rw_file_perms;

--- a/property.te
+++ b/property.te
@@ -11,3 +11,5 @@ type tee_prop, property_type;
 type timekeep_prop, property_type;
 
 type adbtcp_prop, property_type;
+
+type sys_pad_prop, property_type;

--- a/property_contexts
+++ b/property_contexts
@@ -9,3 +9,8 @@ persist.sys.timeadjust     u:object_r:timekeep_prop:s0
 bluetooth.status           u:object_r:bluetooth_prop:s0
 
 adb.network.port              u:object_r:adbtcp_prop:s0
+
+service.pad1.control.result   u:object_r:sys_pad_prop:s0
+service.pad2.control.result   u:object_r:sys_pad_prop:s0
+ril.pad.force_calib.start     u:object_r:radio_prop:s0
+ril.pad.force_calib.result    u:object_r:radio_prop:s0


### PR DESCRIPTION
Required for proximity driver.

Change-Id: I8508061cf3394d14c2a631ee77bb16eb73085148
Signed-off-by: Humberto Borba <humberos@gmail.com>