### PR TITLE
[master] sony: sepolicy: Optimize pad_controller dependencies

### DIFF
--- a/file.te
+++ b/file.te
@@ -79,12 +79,4 @@ type sysfs_timekeep, fs_type, sysfs_type;
 type sysfs_video, fs_type, sysfs_type;
 
 # AD7146 sysfs
-type sysfs_force_calib, sysfs_type, fs_type;
-type sysfs_obj_detect, sysfs_type, fs_type;
-type sysfs_pad_set, sysfs_type, fs_type;
-type sysfs_pad_num, sysfs_type, fs_type;
-type sysfs_pad_data, sysfs_type, fs_type;
-type sysfs_pad_offset, sysfs_type, fs_type;
-type sysfs_sw_updata, sysfs_type, fs_type;
-type sysfs_sw_ad7146_1_state, sysfs_type, fs_type;
-type sysfs_sw_ad7146_2_state, sysfs_type, fs_type;
+type sysfs_pad_controller, sysfs_type, fs_type;

--- a/file_contexts
+++ b/file_contexts
@@ -162,15 +162,15 @@
 /sys/devices/soc0(/.*)?                                             u:object_r:sysfs_socinfo:s0
 
 # AD7146 Proximity
-/sys/devices/virtual/cap_sensor/ad7146/force_calib                  u:object_r:sysfs_force_calib:s0
-/sys/devices/virtual/cap_sensor/ad7146/obj_detect                   u:object_r:sysfs_obj_detect:s0
-/sys/devices/virtual/cap_sensor/ad7146/pad_set                      u:object_r:sysfs_pad_set:s0
-/sys/devices/virtual/cap_sensor/ad7146/pad_num                      u:object_r:sysfs_pad_num:s0
-/sys/devices/virtual/cap_sensor/ad7146/pad_data                     u:object_r:sysfs_pad_data:s0
-/sys/devices/virtual/cap_sensor/ad7146/pad_offset                   u:object_r:sysfs_pad_offset:s0
-/sys/devices/virtual/cap_sensor/ad7146/sw_updata                    u:object_r:sysfs_sw_updata:s0
-/sys/devices/virtual/switch/ad7146_1/state                          u:object_r:sysfs_sw_ad7146_1_state:s0
-/sys/devices/virtual/switch/ad7146_2/state                          u:object_r:sysfs_sw_ad7146_2_state:s0
+/sys/devices/virtual/cap_sensor/ad7146/force_calib                  u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/obj_detect                   u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_set                      u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_num                      u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_data                     u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/pad_offset                   u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/cap_sensor/ad7146/sw_updata                    u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/switch/ad7146_1/state                          u:object_r:sysfs_pad_controller:s0
+/sys/devices/virtual/switch/ad7146_2/state                          u:object_r:sysfs_pad_controller:s0
 
 # Fingerprint
 /sys/bus/spi/devices/spi0\.1/clk_enable                                  u:object_r:sysfs_fingerprintd_writable:s0

--- a/pad_controller.te
+++ b/pad_controller.te
@@ -14,12 +14,4 @@ allow pad_controller sys_pad_prop:property_service { set };
 
 allow pad_controller property_socket:sock_file write;
 
-allow pad_controller sysfs_force_calib:file rw_file_perms;
-allow pad_controller sysfs_obj_detect:file rw_file_perms;
-allow pad_controller sysfs_pad_set:file rw_file_perms;
-allow pad_controller sysfs_pad_num:file rw_file_perms;
-allow pad_controller sysfs_pad_data:file rw_file_perms;
-allow pad_controller sysfs_pad_offset:file rw_file_perms;
-allow pad_controller sysfs_sw_updata:file rw_file_perms;
-allow pad_controller sysfs_sw_ad7146_1_state:file rw_file_perms;
-allow pad_controller sysfs_sw_ad7146_2_state:file rw_file_perms;
+allow pad_controller sysfs_pad_controller:file rw_file_perms;


### PR DESCRIPTION
This patch uses another approach to hadling pad_controller sysfs files.

Signed-off-by: Humberto Borba <humberos@gmail.com>