### PR TITLE
[3.10/3.18 N] Add permissions for urandom, e2fsck, init

### DIFF
--- a/addrsetup.te
+++ b/addrsetup.te
@@ -16,3 +16,5 @@ allow addrsetup addrsetup_data_file:file create_file_perms;
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
 allow addrsetup tad:unix_stream_socket connectto;
+
+allow addrsetup urandom_device:file read;

--- a/debuggerd.te
+++ b/debuggerd.te
@@ -1,0 +1,2 @@
+allow debuggerd urandom_device:file { getattr open read };
+

--- a/fsck.te
+++ b/fsck.te
@@ -1,0 +1,1 @@
+allow fsck urandom_device:file getattr;

--- a/init.te
+++ b/init.te
@@ -2,3 +2,5 @@
 allow init tmpfs:lnk_file create_file_perms;
 
 allow init proc_kernel_sched:file write;
+
+allow init persist_file:dir mounton;

--- a/lmkd.te
+++ b/lmkd.te
@@ -1,1 +1,4 @@
 allow lmkd sysfs_lowmemorykiller:dir search;
+
+allow lmkd urandom_device:file { getattr open read };
+

--- a/logd.te
+++ b/logd.te
@@ -1,0 +1,2 @@
+allow logd urandom_device:file { getattr open read };
+

--- a/ueventd.te
+++ b/ueventd.te
@@ -13,3 +13,8 @@ allow ueventd {
     sysfs_usb_supply
     sysfs_socinfo
 }:file w_file_perms;
+
+allow ueventd device:file relabelfrom;
+allow ueventd urandom_device:file { relabelto setattr };
+allow ueventd vfat:file { open read };
+

--- a/vold.te
+++ b/vold.te
@@ -1,0 +1,2 @@
+allow vold urandom_device:file { getattr open read };
+


### PR DESCRIPTION
Kernel 3.18 needs permissions mostly for /dev/urandom
and then, e2fsck was lacking permissions to open
block devices, resulting in unability to run fsck
on filesystems at boot.
Also, fix init permissions for persist mount.