### PR TITLE
sepolicy: add correct selinux definitions for /misc partition

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -64,11 +64,6 @@
 /dev/block/platform/msm_sdcc\.1/by-name/ssd                    u:object_r:ssd_device:s0
 /dev/block/bootdevice/by-name/ssd                              u:object_r:ssd_device:s0
 
-/dev/block/platform/soc\.0/7824900\.sdhci/by-name/misc         u:object_r:misc_partition:s0
-/dev/block/platform/soc\.0/f9824900\.sdhci/by-name/misc        u:object_r:misc_partition:s0
-/dev/block/platform/msm_sdcc\.1/by-name/misc                   u:object_r:misc_partition:s0
-/dev/block/bootdevice/by-name/misc                             u:object_r:misc_partition:s0
-
 /dev/block/mmcblk0p1                                           u:object_r:trim_area_partition_device:s0
 /dev/block/platform/soc\.0/7824900\.sdhci/by-name/TA           u:object_r:trim_area_partition_device:s0
 /dev/block/platform/soc\.0/f9824900\.sdhci/by-name/TA          u:object_r:trim_area_partition_device:s0
@@ -94,6 +89,12 @@
 /dev/block/platform/soc\.0/f9824900\.sdhci/by-name/cache       u:object_r:cache_block_device:s0
 /dev/block/platform/msm_sdcc\.1/by-name/cache                  u:object_r:cache_block_device:s0
 /dev/block/bootdevice/by-name/cache                            u:object_r:cache_block_device:s0
+
+/dev/block/platform/soc\.0/7824900\.sdhci/by-name/apps_log     u:object_r:misc_block_device:s0
+/dev/block/platform/soc\.0/f9824900\.sdhci/by-name/misc        u:object_r:misc_block_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/apps_log               u:object_r:misc_block_device:s0
+/dev/block/bootdevice/by-name/apps_log                         u:object_r:misc_block_device:s0
+/dev/block/bootdevice/by-name/misc                             u:object_r:misc_block_device:s0
 
 ###################################
 # Dev socket nodes


### PR DESCRIPTION
8974 uses /apps_log as /misc 8994 uses /misc as /misc 8952/56 uses /apps_log as /misc
Following Nexus Angler as base

avoid denials like:
picked from honami - rhine

[   51.159615] type=1400 audit(1474811177.738:5): avc: granted { write } for pid=4156 comm="uncrypt" name="mmcblk0p22" dev="tmpfs" ino=4884 scontext=u:r:uncrypt:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file
[   51.180788] type=1400 audit(1474811177.738:6): avc: granted { write open } for pid=4156 comm="uncrypt" path="/dev/block/mmcblk0p22" dev="tmpfs" ino=4884 scontext=u:r:uncrypt:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file

Signed-off-by: David Viteri <davidteri91@gmail.com>