### PR TITLE
sepolicy: avoid macaddrsetup denials

### DIFF
--- a/addrsetup.te
+++ b/addrsetup.te
@@ -7,7 +7,7 @@ init_daemon_domain(addrsetup)
 # Connect to /dev/socket/tad
 unix_socket_connect(addrsetup, tad, tad)
 
-allow addrsetup self:capability dac_override;
+allow addrsetup { addrsetup self }:capability { chown dac_override fowner fsetid };
 
 type_transition addrsetup system_data_file:file addrsetup_data_file "bluetooth_bdaddr";
 allow addrsetup addrsetup_data_file:dir rw_dir_perms;


### PR DESCRIPTION
[   14.526114] type=1400 audit(10022.679:3): avc: denied { chown } for pid=376 comm=macaddrsetup capability=0 scontext=u:r:addrsetup:s0 tcontext=u:r:addrsetup:s0 tclass=capability permissive=1
[   14.526549] type=1400 audit(10022.679:4): avc: denied { fowner } for pid=376 comm=macaddrsetup capability=3 scontext=u:r:addrsetup:s0 tcontext=u:r:addrsetup:s0 tclass=capability permissive=1
[   14.526623] type=1400 audit(10022.679:5): avc: denied { fsetid } for pid=376 comm=macaddrsetup capability=4 scontext=u:r:addrsetup:s0 tcontext=u:r:addrsetup:s0 tclass=capability permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>