### PR TITLE
sepolicy: SELinux for zram0

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -94,6 +94,8 @@
 /dev/block/platform/msm_sdcc\.1/by-name/cache                  u:object_r:cache_block_device:s0
 /dev/block/bootdevice/by-name/cache                            u:object_r:cache_block_device:s0
 
+/dev/block/zram0                                               u:object_r:swap_block_device:s0
+
 ###################################
 # Dev socket nodes
 #

--- a/vold.te
+++ b/vold.te
@@ -1,0 +1,2 @@
+# zram0
+allow vold swap_block_device:blk_file r_file_perms;


### PR DESCRIPTION
avoid
01-01 02:17:25.970   426   426 I e2fsck  : type=1400 audit(0.0:3): avc: denied { getattr } for path=/dev/block/zram0 dev=tmpfs ino=4812 scontext=u:r:vold:s0 tcontext=u:object_r:swap_block_device:s0 tclass=blk_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>
Signed-off-by: Humberto Borba <humberos@gmail.com>