### PR TITLE
Remove duplicate specification of /sys/devices/platform/bcmdhd_wlan/macaddr

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -199,7 +199,6 @@
 /sys/module/msm_performance(/.*)?                                   u:object_r:sysfs_performance:s0
 
 # Bluetooth
-/sys/devices/platform/bcmdhd_wlan/macaddr                           u:object_r:sysfs_addrsetup:s0
 /sys/devices(/soc\.0)?/bluesleep\.(81|89)/rfkill/rfkill0/state      u:object_r:sysfs_bluetooth_writable:s0
 
 # Storage


### PR DESCRIPTION
FAILED: /run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/target/product/amami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.sorted.tmp 
/bin/bash -c "(/run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/host/linux-x86/bin/checkfc -e /run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/target/product/amami/obj/ETC/sepolicy_intermediates/sepolicy /run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/target/product/amami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.tmp ) && (/run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/host/linux-x86/bin/fc_sort /run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/target/product/amami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.tmp /run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/target/product/amami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.sorted.tmp )"
/run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/target/product/amami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.tmp: Multiple same specifications for /sys/devices/platform/bcmdhd_wlan/macaddr.
Error: could not load context file from /run/media/sc/4T3/ROMs/AICP-n7.0_repo/out/target/product/amami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.tmp
