### PR TITLE
sepolicy: fix error in build after commit 735c1c18f1612a39dbc6adde7e7…

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -199,7 +199,6 @@
 /sys/module/msm_performance(/.*)?                                   u:object_r:sysfs_performance:s0
 
 # Bluetooth
-/sys/devices/platform/bcmdhd_wlan/macaddr                           u:object_r:sysfs_addrsetup:s0
 /sys/devices(/soc\.0)?/bluesleep\.(81|89)/rfkill/rfkill0/state      u:object_r:sysfs_bluetooth_writable:s0
 
 # Storage


### PR DESCRIPTION
…a6c90a198bfba

/mnt/users/alviteri/aospn/out/target/product/honami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.tmp: Multiple same specifications for /sys/devices/platform/bcmdhd_wlan/macaddr.

Signed-off-by: David Viteri <davidteri91@gmail.com>