### PR TITLE
macaddr: remove dangerous sepolicy permissions

### DIFF
--- a/addrsetup.te
+++ b/addrsetup.te
@@ -7,12 +7,9 @@ init_daemon_domain(addrsetup)
 # Connect to /dev/socket/tad
 unix_socket_connect(addrsetup, tad, tad)
 
-allow addrsetup { addrsetup self }:capability { chown dac_override fowner fsetid };
-
-type_transition addrsetup system_data_file:file addrsetup_data_file "bluetooth_bdaddr";
-allow addrsetup addrsetup_data_file:dir rw_dir_perms;
-allow addrsetup addrsetup_data_file:file create_file_perms;
+allow addrsetup bluetooth_data_file:dir rw_dir_perms;
+allow addrsetup bluetooth_data_file:file create_file_perms;
 
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
-allow addrsetup tad:unix_stream_socket connectto;
+unix_socket_connect(addrsetup, tad, tad)

--- a/bluetooth.te
+++ b/bluetooth.te
@@ -1,7 +1,4 @@
 allow bluetooth sysfs:file w_file_perms;
 
-# Allow MAC address file reading
-r_dir_file(bluetooth, addrsetup_data_file)
-
 allow bluetooth smd_device:chr_file rw_file_perms;
 allow bluetooth bluetooth_prop:property_service set;

--- a/file.te
+++ b/file.te
@@ -62,7 +62,6 @@ type ta_data_file, file_type;
 type proc_kernel_sched, fs_type;
 
 type acdb_data_file, file_type, data_file_type;
-type addrsetup_data_file, file_type, data_file_type;
 type timekeep_data_file, file_type, data_file_type;
 
 type sysfs_addrsetup, fs_type, sysfs_type;

--- a/file_contexts
+++ b/file_contexts
@@ -244,7 +244,6 @@
 /data/misc/radio(/.*)?                                              u:object_r:radio_data_file:s0
 /data/misc/fm(/.*)?                                                 u:object_r:fm_data_file:s0
 /data/audio/acdbdata(/.*)?                                          u:object_r:acdb_data_file:s0
-/data/etc(/.*)?                                                     u:object_r:addrsetup_data_file:s0
 /data/time(/.*)?                                                    u:object_r:timekeep_data_file:s0
 
 ###################################


### PR DESCRIPTION
Write the bluetooth macaddr to a place that is natively readable
by bluetooth services, instead of creating new locations which
requires excessive permissions.

Signed-off-by: Adam Farden <adam@farden.cz>