### PR TITLE
sepolicy: fix error in build after commit f9b172049c1cf2abae624716c94…

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -197,7 +197,6 @@
 /sys/module/msm_performance(/.*)?                                   u:object_r:sysfs_performance:s0
 
 # Bluetooth
-/sys/devices/platform/bcmdhd_wlan/macaddr                           u:object_r:sysfs_addrsetup:s0
 /sys/devices(/soc\.0)?/bluesleep\.(81|89)/rfkill/rfkill0/state      u:object_r:sysfs_bluetooth_writable:s0
 
 # Storage


### PR DESCRIPTION
…30f10e8f74049

/mnt/users/alviteri/aospn/out/target/product/honami/obj/ETC/file_contexts.bin_intermediates/file_contexts.device.tmp: Multiple same specifications for /sys/devices/platform/bcmdhd_wlan/macaddr.

Signed-off-by: David Viteri <davidteri91@gmail.com>