### PR TITLE
sepolicy: Use new AOSP label for misc

### DIFF
--- a/device.te
+++ b/device.te
@@ -18,7 +18,7 @@ type qdsp_device, dev_type, mlstrustedobject;
 type device_latency, dev_type;
 
 #Add for fm_radio device
-type  fm_radio_device, dev_type;
+type fm_radio_device, dev_type;
 
 #Add for storage pertitions for EFS partitions
 type modem_efs_partition_device, dev_type;
@@ -34,9 +34,6 @@ type ssr_device, dev_type;
 
 #Ramdump device
 type ramdump_device, dev_type;
-
-#Misc partition
-type misc_partition, dev_type;
 
 # Define IPA devices
 type ipa_dev, dev_type;

--- a/uncrypt.te
+++ b/uncrypt.te
@@ -1,2 +1,0 @@
-# Allow recovery to read the misc partition
-allow uncrypt misc_partition:blk_file rw_file_perms;


### PR DESCRIPTION
misc_partition is deprecated in Nougat
also they are already defined by AOSP

https://android.googlesource.com/platform/system/sepolicy/+/android-7.1.0_r4/device.te#99
https://android.googlesource.com/platform/system/sepolicy/+/android-7.1.0_r4/uncrypt.te#32

Signed-off-by: David Viteri <davidteri91@gmail.com>