### PR TITLE
sony: sepolicy: Address per_mgr denials

### DIFF
--- a/per_mgr.te
+++ b/per_mgr.te
@@ -1,0 +1,1 @@
+r_dir_file(per_mgr, sysfs_pronto)


### PR DESCRIPTION
[   13.994953] type=1400 audit(17091591.159:3): avc: denied { read }
for pid=418 comm="pm-service" name="name" dev="sysfs" ino=20529
scontext=u:r:per_mgr:s0 tcontext=u:object_r:sysfs_pronto:s0
tclass=file permissive=0

[   13.998772] type=1400 audit(17091591.159:4): avc: denied { open }
for pid=418 comm="pm-service"
path="/sys/devices/soc.0/a21b000.qcom,pronto/subsys2/name"
dev="sysfs" ino=20529 scontext=u:r:per_mgr:s0
tcontext=u:object_r:sysfs_pronto:s0 tclass=file permissive=0

[   14.981932] type=1400 audit(1478475975.000:5): avc: denied { read }
for pid=482 comm="pm-proxy" name="name" dev="sysfs" ino=20529
scontext=u:r:per_mgr:s0 tcontext=u:object_r:sysfs_pronto:s0
tclass=file permissive=0

[   14.982325] type=1400 audit(1478475975.000:6): avc: denied { open }
for pid=482 comm="pm-proxy"
path="/sys/devices/soc.0/a21b000.qcom,pronto/subsys2/name"
dev="sysfs" ino=20529 scontext=u:r:per_mgr:s0
tcontext=u:object_r:sysfs_pronto:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I50c2f6dac40f05a0d863cd662fc8d1499ae8a3b7