### PR TITLE
sepolicy: avoid bt denial

### DIFF
--- a/bluetooth.te
+++ b/bluetooth.te
@@ -1,3 +1,3 @@
 allow bluetooth sysfs:file w_file_perms;
-
+allow bluetooth storage_stub_file:dir r_dir_perms;
 allow bluetooth smd_device:chr_file rw_file_perms;


### PR DESCRIPTION
01-01 20:25:52.359  2193  2193 I droid.bluetooth: type=1400 audit(0.0:3): avc: denied { getattr } for path=/storage/emulated dev=tmpfs ino=21678 scontext=u:r:bluetooth:s0 tcontext=u:object_r:storage_stub_file:s0 tclass=dir permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>