### PR TITLE
sony: sepolicy: Address UIM (BT FM) denials

### DIFF
--- a/bluetooth.te
+++ b/bluetooth.te
@@ -1,3 +1,5 @@
-allow bluetooth sysfs:file w_file_perms;
+rw_dir_file(bluetooth, sysfs)
+rw_dir_file(bluetooth, sysfs_bluetooth_writable)
+
 allow bluetooth storage_stub_file:dir r_dir_perms;
 allow bluetooth smd_device:chr_file rw_file_perms;

--- a/file.te
+++ b/file.te
@@ -76,3 +76,7 @@ type sysfs_video, fs_type, sysfs_type;
 
 # AD7146 sysfs
 type sysfs_pad_controller, sysfs_type, fs_type;
+
+# BRCM BT FM
+type brcm_ldisc_sysfs, sysfs_type, fs_type;
+type brcm_uim_exec, exec_type, file_type;

--- a/file_contexts
+++ b/file_contexts
@@ -2,6 +2,7 @@
 # Dev nodes
 #
 /dev/adsprpc-smd                                u:object_r:qdsp_device:s0
+/dev/brcm_bt_drv                                u:object_r:hci_attach_dev:s0
 /dev/cpu_dma_latency                            u:object_r:device_latency:s0
 /dev/diag                                       u:object_r:diag_device:s0
 /dev/kgsl-3d0                                   u:object_r:gpu_device:s0
@@ -115,6 +116,7 @@
 ###################################
 # System files
 #
+/system/bin/brcm-uim-sysfs                      u:object_r:brcm_uim_exec:s0
 /system/bin/macaddrsetup                        u:object_r:addrsetup_exec:s0
 /system/bin/thermanager                         u:object_r:thermanager_exec:s0
 /system/bin/timekeep                            u:object_r:timekeep_exec:s0
@@ -176,23 +178,26 @@
 /sys/devices/virtual/switch/ad7146_1/state                          u:object_r:sysfs_pad_controller:s0
 /sys/devices/virtual/switch/ad7146_2/state                          u:object_r:sysfs_pad_controller:s0
 
+# BRCM BT FM
+/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93(/.*)?            u:object_r:brcm_ldisc_sysfs:s0
+
 # Fingerprint Kitakami
 /sys/bus/spi/devices/spi0\.1/clk_enable                                  u:object_r:sysfs_fingerprintd_writable:s0
-/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/clk_enable    u:object_r:sysfs_fingerprintd_writable:s0
+/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/clk_enable     u:object_r:sysfs_fingerprintd_writable:s0
 /sys/bus/spi/devices/spi0\.1/spi_prepare                                 u:object_r:sysfs_fingerprintd_writable:s0
-/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/spi_prepare   u:object_r:sysfs_fingerprintd_writable:s0
+/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/spi_prepare    u:object_r:sysfs_fingerprintd_writable:s0
 /sys/bus/spi/devices/spi0\.1/wakeup_enable                               u:object_r:sysfs_fingerprintd_writable:s0
-/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/wakeup_enable u:object_r:sysfs_fingerprintd_writable:s0
+/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/wakeup_enable  u:object_r:sysfs_fingerprintd_writable:s0
 /sys/bus/spi/devices/spi0\.1/irq                                         u:object_r:sysfs_fingerprintd_writable:s0
-/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/irq           u:object_r:sysfs_fingerprintd_writable:s0
+/sys/devices/soc\.0/f9923000\.spi/spi_master/spi0/spi0\.1/irq            u:object_r:sysfs_fingerprintd_writable:s0
 
 # Fingerprint Loire
 /sys/devices(/soc\.0)?/fpc1145_device/spi_prepare                       u:object_r:sysfs_fingerprintd_writable:s0
-/sys/devices(/soc\.0)?/fpc1145\.105/spi_prepare                         u:object_r:sysfs_fingerprintd_writable:s0
+/sys/devices(/soc\.0)?/fpc1145\.([0-9])+/spi_prepare                    u:object_r:sysfs_fingerprintd_writable:s0
 /sys/devices(/soc\.0)?/fpc1145_device/wakeup_enable                     u:object_r:sysfs_fingerprintd_writable:s0
-/sys/devices(/soc\.0)?/fpc1145\.105/wakeup_enable                       u:object_r:sysfs_fingerprintd_writable:s0
+/sys/devices(/soc\.0)?/fpc1145\.([0-9])+/wakeup_enable                  u:object_r:sysfs_fingerprintd_writable:s0
 /sys/devices(/soc\.0)?/fpc1145_device/irq                               u:object_r:sysfs_fingerprintd_writable:s0
-/sys/devices(/soc\.0)?/fpc1145\.105/irq                                 u:object_r:sysfs_fingerprintd_writable:s0
+/sys/devices(/soc\.0)?/fpc1145\.([0-9])+/irq                            u:object_r:sysfs_fingerprintd_writable:s0
 
 # Modules
 /sys/module/cpu_boost(/.*)?                                         u:object_r:sysfs_devices_system_cpu:s0
@@ -201,6 +206,7 @@
 
 # Bluetooth
 /sys/devices(/soc\.0)?/bluesleep\.(81|89)/rfkill/rfkill0/state      u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices(/soc\.0)?/bcm43xx.([0-9])+/rfkill/rfkill[0-9](/.*)?    u:object_r:sysfs_bluetooth_writable:s0
 
 # Storage
 /sys/devices(/soc\.0)?/(fd80000|0)?\.qcom,rmtfs_sharedmem/uio/uio0/name                  u:object_r:sysfs_rmt_storage:s0

--- a/init.te
+++ b/init.te
@@ -7,3 +7,6 @@ allow init persist_file:dir mounton;
 
 #FM BCM
 allow init hci_attach_dev:chr_file rw_file_perms;
+allow init brcm_uim_exec:file { execute getattr read open };
+allow init brcm_ldisc_sysfs:lnk_file { read };
+allow init uim:process { siginh noatsecure transition rlimitinh };

--- a/platform_app.te
+++ b/platform_app.te
@@ -1,3 +1,4 @@
 # Allow NFC service to be found
 allow platform_app nfc_service:service_manager find;
+allow platform_app fm_radio_device:chr_file { open read };
 

--- a/ueventd.te
+++ b/ueventd.te
@@ -7,6 +7,9 @@ r_dir_file(ueventd, persist_file)
 # For wifi to access wifi_data_file
 r_dir_file(ueventd, wifi_data_file)
 
+# For BT to access sysfs_bluetooth_writable
+rw_dir_file(ueventd, sysfs_bluetooth_writable)
+
 allow ueventd {
     sysfs_battery_supply
     sysfs_thermal

--- a/uim.te
+++ b/uim.te
@@ -1,0 +1,11 @@
+type uim, domain;
+
+rw_dir_file(uim, sysfs)
+rw_dir_file(uim, brcm_ldisc_sysfs)
+allow uim brcm_uim_exec:file { entrypoint read execute };
+allow uim bluetooth_data_file:file { read open };
+allow uim hci_attach_dev:chr_file { read write ioctl open };
+allow uim self:capability { net_admin dac_override };
+allow uim sysfs_bluetooth_writable:dir search;
+allow uim sysfs_bluetooth_writable:file { read write open };
+


### PR DESCRIPTION
The service "uim /system/bin/brcm-uim-sysfs"
should be labeled as seclabel u:r:uim:s0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I5e943e3eef6f344040dd1ba975442a456fdbbf35