### PR TITLE
sepolicy: avoid 7.1.x denials

### DIFF
--- a/audioserver.te
+++ b/audioserver.te
@@ -1,1 +1,3 @@
 r_dir_file(audioserver, sysfs)
+
+allow audioserver rootfs:lnk_file getattr;

--- a/bootanim.te
+++ b/bootanim.te
@@ -1,1 +1,3 @@
 set_prop(bootanim, boot_animation_prop)
+
+allow bootanim rootfs:lnk_file getattr;

--- a/cameraserver.te
+++ b/cameraserver.te
@@ -3,3 +3,4 @@ allow cameraserver mm-qcamerad:unix_dgram_socket sendto;
 allow cameraserver camera_data_file:sock_file write;
 
 allow cameraserver gpu_device:chr_file rw_file_perms;
+allow cameraserver rootfs:lnk_file getattr;

--- a/init.te
+++ b/init.te
@@ -7,6 +7,6 @@ allow init persist_file:dir mounton;
 
 #FM BCM
 allow init hci_attach_dev:chr_file rw_file_perms;
-allow init brcm_uim_exec:file { execute getattr read open };
+allow init { debugfs brcm_uim_exec }:file rw_file_perms;
 allow init brcm_ldisc_sysfs:lnk_file { read };
 allow init uim:process { siginh noatsecure transition rlimitinh };

--- a/mediacodec.te
+++ b/mediacodec.te
@@ -1,0 +1,1 @@
+allow mediacodec rootfs:lnk_file getattr;

--- a/mediadrmserver.te
+++ b/mediadrmserver.te
@@ -1,0 +1,1 @@
+allow mediadrmserver rootfs:lnk_file getattr;

--- a/uim.te
+++ b/uim.te
@@ -7,3 +7,4 @@ rw_dir_file(uim, sysfs_bluetooth_writable)
 allow uim brcm_uim_exec:file { entrypoint getattr read execute };
 allow uim hci_attach_dev:chr_file { read write ioctl open };
 allow uim self:capability { net_admin dac_override };
+allow uim rootfs:lnk_file getattr;


### PR DESCRIPTION
01-09 06:49:29.579     1     1 I init    : type=1400 audit(0.0:3): avc: denied { write } for name=tracing_on dev=debugfs ino=6843 scontext=u:r:init:s0 tcontext=u:object_r:debugfs:s0 tclass=file permissive=1
01-09 06:49:30.809   520   520 I audioserver: type=1400 audit(0.0:4): avc: denied { getattr } for path=/vendor dev=rootfs ino=10902 scontext=u:r:audioserver:s0 tcontext=u:object_r:rootfs:s0 tclass=lnk_file permissive=1
01-09 06:49:30.809   522   522 I cameraserver: type=1400 audit(0.0:5): avc: denied { getattr } for path=/vendor dev=rootfs ino=10902 scontext=u:r:cameraserver:s0 tcontext=u:object_r:rootfs:s0 tclass=lnk_file permissive=1
01-09 06:49:30.829   526   526 I mediacodec: type=1400 audit(0.0:6): avc: denied { getattr } for path=/vendor dev=rootfs ino=10902 scontext=u:r:mediacodec:s0 tcontext=u:object_r:rootfs:s0 tclass=lnk_file permissive=1
01-09 06:49:30.869   528   528 I mediadrmserver: type=1400 audit(0.0:7): avc: denied { getattr } for path=/vendor dev=rootfs ino=10902 scontext=u:r:mediadrmserver:s0 tcontext=u:object_r:rootfs:s0 tclass=lnk_file permissive=1
01-09 06:49:31.179   642   642 I brcm-uim-sysfs: type=1400 audit(0.0:8): avc: denied { getattr } for path=/vendor dev=rootfs ino=10902 scontext=u:r:uim:s0 tcontext=u:object_r:rootfs:s0 tclass=lnk_file permissive=1
12-09 14:19:42.769   666   666 I bootanimation: type=1400 audit(0.0:9): avc: denied { getattr } for path=/vendor dev=rootfs ino=10902 scontext=u:r:bootanim:s0 tcontext=u:object_r:rootfs:s0 tclass=lnk_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>