### PR TITLE
sepolicy: fix error in build after commit 4bfaed0e450e87208e3abe36580…

### DIFF
--- a/init.te
+++ b/init.te
@@ -4,9 +4,10 @@ allow init tmpfs:lnk_file create_file_perms;
 allow init proc_kernel_sched:file write;
 
 allow init persist_file:dir mounton;
+allow init debugfs:file w_file_perms;
 
 #FM BCM
 allow init hci_attach_dev:chr_file rw_file_perms;
-allow init { debugfs brcm_uim_exec }:file rw_file_perms;
+allow init brcm_uim_exec:file { execute getattr read open };
 allow init brcm_ldisc_sysfs:lnk_file { read };
 allow init uim:process { siginh noatsecure transition rlimitinh };


### PR DESCRIPTION
…052460779cd2e

neverallow case
libsepol.report_failure: neverallow on line 316 of system/sepolicy/domain.te (or line 8984 of policy.conf) violated by allow init brcm_uim_exec:file { write append };

Signed-off-by: David Viteri <davidteri91@gmail.com>