### PR TITLE
[master] sony: sepolicy: Update brcm bt fm sysfs path

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -179,7 +179,7 @@
 /sys/devices/virtual/switch/ad7146_2/state                          u:object_r:sysfs_pad_controller:s0
 
 # BRCM BT FM
-/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93(/.*)?            u:object_r:brcm_ldisc_sysfs:s0
+/sys/bus/platform/drivers/bcm_ldisc/soc\:bcmbt_ldisc(/.*)?          u:object_r:brcm_ldisc_sysfs:s0
 
 # Fingerprint Kitakami
 /sys/bus/spi/devices/spi0\.1/clk_enable                                  u:object_r:sysfs_fingerprintd_writable:s0


### PR DESCRIPTION
it is a 3.18 kernel requirement.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: If2f8e131ddc7a7218949a899872b9b170cc46fec