### PR TITLE
sony: sepolicy: Address macaddrsetup denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -244,6 +244,7 @@
 /sys/devices/soc/fb000000\.qcom,wcnss-wlan/wcnss_mac_addr                                u:object_r:sysfs_addrsetup:s0
 /sys/devices/platform/bcmdhd_wlan/macaddr                                                u:object_r:sysfs_addrsetup:s0
 /sys/devices/soc/bcmdhd_wlan.(90|114)/macaddr                                            u:object_r:sysfs_addrsetup:s0
+/sys/devices/soc/soc\:bcmdhd_wlan/macaddr                                                u:object_r:sysfs_addrsetup:s0
 /sys/devices/soc/(fb21b000|a21b000)\.qcom,pronto/subsys2/name                            u:object_r:sysfs_pronto:s0
 
 ###################################


### PR DESCRIPTION
Required at 3.18 kernel

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I2dd01be93a19ac3df190b062f4e4a4c8f9f0f3d3