### PR TITLE
sepolicy: avoid memory explorer denials

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -9,6 +9,9 @@ allow system_app activity_service:service_manager find;
 allow system_app connectivity_service:service_manager find;
 allow system_app display_service:service_manager find;
 allow system_app network_management_service:service_manager find;
+allow system_app media_rw_data_file:dir r_dir_perms;
+
+# TimeKeep
 allow system_app timekeep_data_file:dir { create_dir_perms search };
 allow system_app timekeep_data_file:file create_file_perms;
 


### PR DESCRIPTION
12-13 09:57:13.190  3924  3924 I MemoryMeasureme: type=1400 audit(0.0:3): avc: denied { read open } for path=/data/media/0 dev=mmcblk0p42 ino=670435 scontext=u:r:system_app:s0 tcontext=u:object_r:media_rw_data_file:s0 tclass=dir permissive=1
12-13 09:57:13.190  3924  3924 I MemoryMeasureme: type=1400 audit(0.0:4): avc: denied { search } for name=0 dev=mmcblk0p42 ino=670435 scontext=u:r:system_app:s0 tcontext=u:object_r:media_rw_data_file:s0 tclass=dir permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>