### PR TITLE
[HAL1]sepolicy: avoid cam denials

### DIFF
--- a/mediaserver.te
+++ b/mediaserver.te
@@ -3,4 +3,7 @@ binder_call(mediaserver, rild)
 allow mediaserver self:socket create_socket_perms;
 allow mediaserver camera_data_file:sock_file w_file_perms;
 
+# HAL1 hack
+allow mediaserver mm-qcamerad:unix_dgram_socket sendto; 
+
 qmux_socket(mediaserver)

--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -17,3 +17,6 @@ allow mm-qcamerad camera_data_file:sock_file create_file_perms;
 allow mm-qcamerad { graphics_device video_device }:chr_file rw_file_perms;
 allow mm-qcamerad sysfs_video:file r_file_perms;
 allow mm-qcamerad { cameraserver surfaceflinger }:fd use;
+
+# HAL1 hack
+allow mm-qcamerad mediaserver:fd use;


### PR DESCRIPTION
12-22 12:47:08.587  9508  9508 I mm-qcamera-daem: type=1400 audit(0.0:28): avc: denied { use } for path=anon_inode:dmabuf dev=anon_inodefs ino=12273 scontext=u:r:mm-qcamerad:s0 tcontext=u:r:mediaserver:s0 tclass=fd permissive=1
12-22 12:47:28.107  2274  2274 I Binder:1113_2: type=1400 audit(0.0:29): avc: denied { sendto } for path=/data/misc/camera/cam_socket2 scontext=u:r:mediaserver:s0 tcontext=u:r:mm-qcamerad:s0 tclass=unix_dgram_socket permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>

merge this after
https://github.com/sonyxperiadev/device-sony-rhine/pull/270
https://github.com/sonyxperiadev/device-sony-shinano/pull/332