### PR TITLE
sepolicy: avoid cam denials in enforcing

### DIFF
--- a/mediaserver.te
+++ b/mediaserver.te
@@ -4,6 +4,7 @@ allow mediaserver self:socket create_socket_perms;
 allow mediaserver camera_data_file:sock_file w_file_perms;
 
 # HAL1 hack
-allow mediaserver mm-qcamerad:unix_dgram_socket sendto; 
+allow mediaserver mm-qcamerad:unix_dgram_socket sendto;
+allow mediaserver camera_data_file:dir search; 
 
 qmux_socket(mediaserver)

--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -20,3 +20,5 @@ allow mm-qcamerad { cameraserver surfaceflinger }:fd use;
 
 # HAL1 hack
 allow mm-qcamerad mediaserver:fd use;
+allow mm-qcamerad graphics_device:dir search;
+allow mm-qcamerad camera_data_file:file create;


### PR DESCRIPTION
12-30 20:52:55.495   390   390 W mediaserver: type=1400 audit(0.0:2910): avc: denied { search } for name=camera dev=mmcblk0p25 ino=431675 scontext=u:r:mediaserver:s0 tcontext=u:object_r:camera_data_file:s0 tclass=dir permissive=0
12-30 22:21:58.533  1041  1041 W CAM_MctServ: type=1400 audit(0.0:4): avc: denied { search } for name="graphics" dev="tmpfs" ino=6069 scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:graphics_device:s0 tclass=dir permissive=0
12-31 10:03:57.831 11212 11212 W CAM_MctServ: type=1400 audit(0.0:48): avc: denied { create } for name="fdAlbum" scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:camera_data_file:s0 tclass=file permissive=0

permissive mode too

01-04 17:11:10.743  7748  7748 I CAM_MctServ: type=1400 audit(0.0:7): avc: denied { create } for name="fdAlbum" scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:camera_data_file:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>