### PR TITLE
sepolicy: avoid vold denials

### DIFF
--- a/vold.te
+++ b/vold.te
@@ -1,2 +1,3 @@
 allow vold urandom_device:file { getattr open read };
+allow vold storage_stub_file:dir rw_dir_perms;
 


### PR DESCRIPTION
01-04 21:15:33.997   455   455 I vold    : type=1400 audit(0.0:7): avc: denied { read } for name=2D3B-1CF0 dev=tmpfs ino=82146 scontext=u:r:vold:s0 tcontext=u:object_r:storage_stub_file:s0 tclass=dir permissive=1
01-04 21:15:33.997   455   455 I vold    : type=1400 audit(0.0:8): avc: denied { open } for path=/storage/2D3B-1CF0 dev=tmpfs ino=82146 scontext=u:r:vold:s0 tcontext=u:object_r:storage_stub_file:s0 tclass=dir permissive=1
01-04 21:15:33.997   455   455 I vold    : type=1400 audit(0.0:9): avc: denied { write } for name=2D3B-1CF0 dev=tmpfs ino=82146 scontext=u:r:vold:s0 tcontext=u:object_r:storage_stub_file:s0 tclass=dir permissive=1
01-04 21:15:33.997   455   455 I vold    : type=1400 audit(0.0:10): avc: denied { add_name } for name=Android scontext=u:r:vold:s0 tcontext=u:object_r:storage_stub_file:s0 tclass=dir permissive=1

those denials can be seen formatting external SD from settings

Signed-off-by: David Viteri <davidteri91@gmail.com>