### PR TITLE
sepolicy: avoid 3.18 denials

### DIFF
--- a/fingerprintd.te
+++ b/fingerprintd.te
@@ -1,2 +1,3 @@
 allow fingerprintd sysfs_fingerprintd_writable:file rw_file_perms;
 allow fingerprintd tee_device:chr_file rw_file_perms;
+allow fingerptintd sysfs:file w_file_perms;

--- a/init.te
+++ b/init.te
@@ -5,6 +5,7 @@ allow init proc_kernel_sched:file write;
 
 allow init persist_file:dir mounton;
 allow init debugfs:file w_file_perms;
+allow init sysfs:dir w_dir_perms;
 
 #FM BCM
 allow init hci_attach_dev:chr_file rw_file_perms;

--- a/netmgrd.te
+++ b/netmgrd.te
@@ -48,6 +48,7 @@ allow netmgrd netmgrd_socket:dir create_dir_perms;
 allow netmgrd netmgrd_socket:sock_file create_file_perms;
 
 allow netmgrd shell_exec:file rx_file_perms;
+allow netmgrd default_prop:property_service set;
 
 #Allow netmgrd to use wakelock
 wakelock_use(netmgrd)


### PR DESCRIPTION
[   21.956000] type=1400 audit(8045725.589:3): avc: denied { write } for pid=1 comm=init name=interactive dev=sysfs ino=37526 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=1
58] init: avc:  denied  { set } for property=persist.net.doxlat pid=477 uid=1001 gid=3003 scontext=u:r:netmgrd:s0 tcontext=u:object_r:default_prop:s0 tclass=property_service permissive=1
[   38.862318] type=1400 audit(1483657932.759:4): avc: denied { write } for pid=499 comm=fingerprintd name=spi_prepare dev=sysfs ino=28908 scontext=u:r:fingerprintd:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>