### PR TITLE
sepolicy: avoid Zram denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -247,6 +247,9 @@
 /sys/devices/soc/soc\:bcmdhd_wlan/macaddr                                                u:object_r:sysfs_addrsetup:s0
 /sys/devices/soc/(fb21b000|a21b000)\.qcom,pronto/subsys2/name                            u:object_r:sysfs_pronto:s0
 
+# Zram
+/sys/devices/virtual/block/zram0/mem_used_total                                          u:object_r:sysfs_zram:s0
+
 ###################################
 # data files
 #

--- a/untrusted_app.te
+++ b/untrusted_app.te
@@ -1,2 +1,5 @@
 allow untrusted_app vfat:dir rw_dir_perms;
 allow untrusted_app vfat:file create;
+
+allow untrusted_app sysfs_zram:dir r_dir_perms;
+allow untrusted_app sysfs_zram:file r_file_perms;


### PR DESCRIPTION
Allow ContacsProvider access to Zram block

01-09 10:55:41.409  3457  3457 I ContactsProvide: type=1400 audit(0.0:3): avc: denied { search } for name=zram0 dev=sysfs ino=12651 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=dir permissive=1
01-09 10:55:41.409  3457  3457 I ContactsProvide: type=1400 audit(0.0:4): avc: denied { read } for name=mem_used_total dev=sysfs ino=12718 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=file permissive=1
01-09 10:55:41.419  3457  3457 I ContactsProvide: type=1400 audit(0.0:5): avc: denied { open } for path=/sys/devices/virtual/block/zram0/mem_used_total dev=sysfs ino=12718 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=file permissive=1
01-09 10:55:41.419  3457  3457 I ContactsProvide: type=1400 audit(0.0:6): avc: denied { getattr } for path=/sys/devices/virtual/block/zram0/mem_used_total dev=sysfs ino=12718 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs_zram:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>