### PR TITLE
sepolicy: avoid settings denials

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -11,6 +11,7 @@ allow system_app display_service:service_manager find;
 allow system_app network_management_service:service_manager find;
 allow system_app timekeep_data_file:dir { create_dir_perms search };
 allow system_app timekeep_data_file:file create_file_perms;
+allow system_app media_rw_data_file:dir r_dir_perms;
 
 # ExtendedSettings props
 allow system_app adbtcpes_prop:property_service set;


### PR DESCRIPTION
01-10 23:53:55.640 11242 11242 I MemoryMeasureme: type=1400 audit(0.0:21): avc: denied { read open } for path=/data/media/0 dev=mmcblk0p25 ino=757395 scontext=u:r:system_app:s0 tcontext=u:object_r:media_rw_data_file:s0 tclass=dir permissive=1
01-10 23:53:55.650 11242 11242 I MemoryMeasureme: type=1400 audit(0.0:22): avc: denied { search } for name=0 dev=mmcblk0p25 ino=757395 scontext=u:r:system_app:s0 tcontext=u:object_r:media_rw_data_file:s0 tclass=dir permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>