### PR TITLE
sepolicy: avoid keystore denials

### DIFF
--- a/keystore.te
+++ b/keystore.te
@@ -1,3 +1,3 @@
 allow keystore tee_device:chr_file rw_file_perms;
 
-allow keystore firmware_file:file r_file_perms;
+allow keystore { firmware_file tee_prop }:file r_file_perms;


### PR DESCRIPTION
02-01 01:25:04.249   458   458 I keystore: type=1400 audit(0.0:3): avc: denied { read } for name="u:object_r:tee_prop:s0" dev="tmpfs" ino=11687 scontext=u:r:keystore:s0 tcontext=u:object_r:tee_prop:s0 tclass=file permissive=1
02-01 01:25:04.249   458   458 I keystore: type=1400 audit(0.0:4): avc: denied { open } for path="/dev/__properties__/u:object_r:tee_prop:s0" dev="tmpfs" ino=11687 scontext=u:r:keystore:s0 tcontext=u:object_r:tee_prop:s0 tclass=file permissive=1
02-01 01:25:04.249   458   458 I keystore: type=1400 audit(0.0:5): avc: denied { getattr } for path="/dev/__properties__/u:object_r:tee_prop:s0" dev="tmpfs" ino=11687 scontext=u:r:keystore:s0 tcontext=u:object_r:tee_prop:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>