### PR TITLE
sepolicy: avoid denials

### DIFF
--- a/drmserver.te
+++ b/drmserver.te
@@ -1,0 +1,1 @@
+allow drmserver ringtone_file:file read;


### PR DESCRIPTION
01-31 21:59:32.788  4339  4339 I Binder:475_2: type=1400 audit(0.0:13): avc: denied { read } for path=/data/system_de/0/ringtones/alarm_alert_cache dev=mmcblk0p51 ino=114246 scontext=u:r:drmserver:s0 tcontext=u:object_r:ringtone_file:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>