### PR TITLE
sepolicy: avoid mac denials

### DIFF
--- a/addrsetup.te
+++ b/addrsetup.te
@@ -10,6 +10,6 @@ unix_socket_connect(addrsetup, tad, tad)
 allow addrsetup bluetooth_data_file:dir rw_dir_perms;
 allow addrsetup bluetooth_data_file:file create_file_perms;
 
-allow addrsetup sysfs_addrsetup:file rw_file_perms;
+allow addrsetup { sysfs sysfs_addrsetup }:file rw_file_perms;
 
 unix_socket_connect(addrsetup, tad, tad)


### PR DESCRIPTION
06-30 15:32:14.307   437   437 I macaddrsetup: type=1400 audit(0.0:3): avc: denied { write } for name=macaddr dev=sysfs ino=22442 scontext=u:r:addrsetup:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
06-30 15:32:43.777  3152  3152 I macaddrsetup: type=1400 audit(0.0:4): avc: denied { write } for name=macaddr dev=sysfs ino=22442 scontext=u:r:addrsetup:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>