### PR TITLE
sepolicy: update mac address path for loire

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -244,7 +244,7 @@
 # WiFi MAC address
 /sys/devices(/soc\.0)?/fb000000\.qcom,wcnss-wlan/wcnss_mac_addr                          u:object_r:sysfs_addrsetup:s0
 /sys/devices/platform/bcmdhd_wlan/macaddr                                                u:object_r:sysfs_addrsetup:s0
-/sys/devices(/soc\.0)?/bcmdhd_wlan.(90|114)/macaddr                                      u:object_r:sysfs_addrsetup:s0
+/sys/devices(/soc\.0)?/bcmdhd_wlan.(90|115)/macaddr                                      u:object_r:sysfs_addrsetup:s0
 /sys/devices(/soc\.0)?/(fb21b000|a21b000)\.qcom,pronto/subsys2/name                      u:object_r:sysfs_pronto:s0
 
 ###################################


### PR DESCRIPTION
correct value is 115 not 114 see https://github.com/sonyxperiadev/device-sony-loire/commit/3faf836a41e90d69edbdb9b1a70eba2d628831b8

Signed-off-by: David Viteri <davidteri91@gmail.com>