### PR TITLE
sepolicy: avoid rild denial

### DIFF
--- a/rild.te
+++ b/rild.te
@@ -16,7 +16,7 @@ netmgr_socket(rild);
 use_per_mgr(rild);
 
 allow rild sysfs_pronto:file r_file_perms;
-allow rild mediaserver_service:service_manager find;
+allow rild { audioserver_service mediaserver_service }:service_manager find;
 allow rild system_health_monitor_device:chr_file r_file_perms;
 
 r_dir_file(rild, sysfs_socinfo)


### PR DESCRIPTION
12-01 16:37:34.378   470   470 E SELinux : avc:  denied  { find } for service=media.audio_flinger pid=531 uid=1001 scontext=u:r:rild:s0 tcontext=u:object_r:audioserver_service:s0 tclass=service_manager permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>