### PR TITLE
sepolicy: avoid camera denials

### DIFF
--- a/mediaserver.te
+++ b/mediaserver.te
@@ -3,4 +3,7 @@ binder_call(mediaserver, rild)
 allow mediaserver self:socket create_socket_perms;
 allow mediaserver camera_data_file:sock_file w_file_perms;
 
+allow mediaserver camera_data_file:dir search;
+allow mediaserver mm-qcamerad:unix_dgram_socket sendto;
+
 qmux_socket(mediaserver)

--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -20,3 +20,5 @@ allow mm-qcamerad { cameraserver surfaceflinger }:fd use;
 allow mm-qcamerad camera_prop:property_service set;
 allow mm-qcamerad property_socket:sock_file write;
 allow mm-qcamerad init:unix_stream_socket connectto;
+
+allow mm-qcamerad mediaserver:fd use;


### PR DESCRIPTION
enforcing mode on 8952

02-16 13:27:57.417  2870  2870 W mediaserver: type=1400 audit(0.0:1950): avc: denied { search } for name=camera dev=mmcblk0p51 ino=171403 scontext=u:r:mediaserver:s0 tcontext=u:object_r:camera_data_file:s0 tclass=dir permissive=0
02-16 13:51:46.700   500   500 W mediaserver: type=1400 audit(0.0:33): avc: denied { sendto } for path="/data/misc/camera/cam_socket1" scontext=u:r:mediaserver:s0 tcontext=u:r:mm-qcamerad:s0 tclass=unix_dgram_socket permissive=0
02-16 13:51:46.933   500   500 W mediaserver: type=1400 audit(0.0:34): avc: denied { sendto } for path="/data/misc/camera/cam_socket2" scontext=u:r:mediaserver:s0 tcontext=u:r:mm-qcamerad:s0 tclass=unix_dgram_socket permissive=0
02-16 13:59:09.470   495   495 W mm-qcamera-daem: type=1400 audit(0.0:7): avc: denied { use } for path="anon_inode:dmabuf" dev="anon_inodefs" ino=10355 scontext=u:r:mm-qcamerad:s0 tcontext=u:r:mediaserver:s0 tclass=fd permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>