### PR TITLE
[n-mr0] sepolicy: add vold and sdcard related rules

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -10,6 +10,7 @@ allow system_app connectivity_service:service_manager find;
 allow system_app display_service:service_manager find;
 allow system_app network_management_service:service_manager find;
 allow system_app media_rw_data_file:dir r_dir_perms;
+allow system_app fuse_device:filesystem getattr;
 
 # TimeKeep
 allow system_app timekeep_data_file:dir { create_dir_perms search };

--- a/vold.te
+++ b/vold.te
@@ -1,3 +1,4 @@
 allow vold urandom_device:file { getattr open read };
 allow vold storage_stub_file:dir rw_dir_perms;
+allow vold fuse_device:dir { open read search write };
 


### PR DESCRIPTION
system_app.te: settings app needs access to fuse to get usage stats
vold.te: selinux reports vold denies when mounting sdcard

the denies solved are:
[ 1182.165576] type=1400 audit(1488221389.184:215): avc: denied {
getattr } for pid=7174 comm="ndroid.settings" name="/" dev="mmcblk1p1"
ino=1 scontext=u:r:system_app:s0 tcontext=u:object_r:fuse_device:s0
tclass=filesystem permissive=0
[ 1953.618601] type=1400 audit(1488222160.634:552): avc: denied { write
} for pid=424 comm="vold" name="data" dev="mmcblk1p1" ino=3
scontext=u:r:vold:s0 tcontext=u:object_r:fuse_device:s0 tclass=dir
permissive=0
[ 4819.557559] type=1400 audit(1488225299.224:744): avc: denied { read
open } for pid=424 comm="vold" path="/mnt/media_rw/24B5-1131"
dev="mmcblk1p1" ino=1 scontext=u:r:vold:s0
tcontext=u:object_r:fuse_device:s0 tclass=dir permissive=0
[ 1082.477508] type=1400 audit(1488221289.504:184): avc: denied { search
} for pid=424 comm="vold" name="/" dev="mmcblk1p1" ino=1
scontext=u:r:vold:s0 tcontext=u:object_r:fuse_device:s0 tclass=dir
permissive=0

Change-Id: Ic2c15b9cb50f4b5a348e6a013a4b06c3b43eab2a