### PR TITLE
sony: sepolicy: Address kernel and uncrypt denials

### DIFF
--- a/kernel.te
+++ b/kernel.te
@@ -1,4 +1,5 @@
 allow kernel device:dir create_dir_perms;
+allow kernel device:chr_file { create setattr };
 allow kernel tmpfs:file create_file_perms;
 allow kernel tmpfs:dir create_dir_perms;
 allow kernel rootfs:file rx_file_perms;
@@ -6,6 +7,7 @@ allow kernel block_device:blk_file rw_file_perms;
 allow kernel touchfusion_exec:file relabelto;
 
 allow kernel self:socket create;
+allow kernel self:capability { mknod };
 
 domain_auto_trans(kernel, touchfusion_exec, touchfusion)
 

--- a/uncrypt.te
+++ b/uncrypt.te
@@ -1,0 +1,1 @@
+allow uncrypt kmsg_device:chr_file { write };


### PR DESCRIPTION
avc: denied { mknod } for capability=27
scontext=u:r:kernel:s0 tcontext=u:r:kernel:s0 tclass=capability permissive=0

avc: denied { create } for name="hwC0D49" scontext=u:r:kernel:s0
tcontext=u:object_r:device:s0 tclass=chr_file permissive=0

avc: denied { write } for name="kmsg" dev="tmpfs" ino=6922
scontext=u:r:uncrypt:s0 tcontext=u:object_r:kmsg_device:s0
tclass=chr_file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I5312991bef7d031a9fa5a9afce6904ddacefcfcc