### PR TITLE
sony: sepolicy: Address kernel denied

### DIFF
--- a/kernel.te
+++ b/kernel.te
@@ -1,5 +1,5 @@
 allow kernel device:dir create_dir_perms;
-allow kernel device:chr_file { create setattr };
+allow kernel device:chr_file { create setattr getattr };
 allow kernel tmpfs:file create_file_perms;
 allow kernel tmpfs:dir create_dir_perms;
 allow kernel rootfs:file rx_file_perms;


### PR DESCRIPTION
avc: denied { getattr } for path="/input/event8"
dev="devtmpfs" ino=103800 scontext=u:r:kernel:s0
tcontext=u:object_r:device:s0 tclass=chr_file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ieec869f191238b4956c29db68f28560c779ebf21