### PR TITLE
sepolicy: avoid bt denials

### DIFF
--- a/bluetooth.te
+++ b/bluetooth.te
@@ -3,3 +3,5 @@ rw_dir_file(bluetooth, sysfs_bluetooth_writable)
 
 allow bluetooth smd_device:chr_file rw_file_perms;
 allow bluetooth bluetooth_prop:property_service set;
+
+allow bluetooth bluetooth:unix_stream_socket ioctl;


### PR DESCRIPTION
03-13 22:00:22.049  5841  5841 I Binder_2: type=1400 audit(0.0:13): avc: denied { ioctl } for path=socket:[33284] dev=sockfs ino=33284 ioctlcmd=7704 scontext=u:r:bluetooth:s0 tcontext=u:r:bluetooth:s0 tclass=unix_stream_socket permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>