### PR TITLE
[n-mr1] sony: sepolicy: Fix touch_fusion denials

### DIFF
--- a/init.te
+++ b/init.te
@@ -1,5 +1,7 @@
 #For sdcard
 allow init tmpfs:lnk_file create_file_perms;
+allow init tmpfs:file create_file_perms;
+allow init tmpfs:dir create_dir_perms;
 
 allow init proc_kernel_sched:file write;
 

--- a/kernel.te
+++ b/kernel.te
@@ -4,12 +4,12 @@ allow kernel tmpfs:file create_file_perms;
 allow kernel tmpfs:dir create_dir_perms;
 allow kernel rootfs:file rx_file_perms;
 allow kernel block_device:blk_file rw_file_perms;
-allow kernel touchfusion_exec:file relabelto;
 
-allow kernel self:socket create;
-allow kernel self:capability { mknod };
-
-domain_auto_trans(kernel, touchfusion_exec, touchfusion)
+userdebug_or_eng(`
+  allow kernel self:capability { dac_read_search dac_override };
+  allow kernel self:capability { net_admin mknod };
+  allow kernel self: { socket netlink_socket } create_socket_perms;
+')
 
 # Access firmware_file
 r_dir_file(kernel, firmware_file)

--- a/touchfusion.te
+++ b/touchfusion.te
@@ -1,21 +1,24 @@
 type touchfusion, domain, domain_deprecated;
+
 type touchfusion_exec, exec_type, file_type;
 
 init_daemon_domain(touchfusion)
 
-userdebug_or_eng(`
-  allow touchfusion self:capability { 
-    dac_read_search
-    dac_override
-    net_admin
-    setgid
-    setuid
-    sys_nice
-  };
-  allow touchfusion self:socket create_socket_perms;
-  allow touchfusion self:netlink_socket create_socket_perms;
-')
+domain_auto_trans(kernel, touchfusion_exec, touchfusion);
 
 allow touchfusion kmsg_device:chr_file rw_file_perms;
+
+allow touchfusion graphics_device:dir r_dir_perms;
+
+allow touchfusion self: { netlink_socket netlink_generic_socket } create_socket_perms;
+
+allow touchfusion graphics_device:chr_file rw_file_perms;
+
+allow touchfusion self:capability { setgid setuid };
+
+userdebug_or_eng(`
+allow touchfusion self:capability { sys_nice net_admin dac_override dac_read_search };
+')
+
 allow touchfusion cgroup:dir create_dir_perms;
 allow touchfusion cgroup:file create_file_perms;

--- a/ueventd.te
+++ b/ueventd.te
@@ -17,6 +17,9 @@ allow ueventd {
     sysfs_socinfo
 }:file w_file_perms;
 
+allow ueventd tmpfs:file create_file_perms;
+allow ueventd tmpfs:dir create_dir_perms;
+
 allow ueventd device:file relabelfrom;
 allow ueventd urandom_device:file { relabelto setattr };
 allow ueventd vfat:file { open read };


### PR DESCRIPTION
It is required for karin's touchscreen (touch_fusion).

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I6295c7b1e02024fa0ffb2d72cd70e768cd895678