### PR TITLE
sepolicy: avoid mediaserver denials

### DIFF
--- a/mediaserver.te
+++ b/mediaserver.te
@@ -7,4 +7,7 @@ allow mediaserver camera_data_file:sock_file w_file_perms;
 allow mediaserver mm-qcamerad:unix_dgram_socket sendto;
 allow mediaserver camera_data_file:dir search; 
 
+allow mediaserver cameraserver_service:service_manager add;
+allow mediaserver cameraproxy_service:service_manager find;
+
 qmux_socket(mediaserver)


### PR DESCRIPTION
avc: denied { add } for service=media.camera pid=529 uid=1013 scontext=u:r:mediaserver:s0 tcontext=u:object_r:cameraserver_service:s0 tclass=service_manager permissive= 0
avc: denied { find } for service=media.camera.proxy pid=532 uid=1013 scontext=u:r:mediaserver:s0 tcontext=u:object_r:cameraproxy_service:s0 tclass=service_manager permissive=0