### PR TITLE
[master] Address rild, priv_app and untrusted_app denials.

### DIFF
--- a/priv_app.te
+++ b/priv_app.te
@@ -1,2 +1,13 @@
 allow priv_app vfat:dir rw_dir_perms;
-allow priv_app vfat:file create;
+allow priv_app vfat:dir create;
+allow priv_app vfat:dir { setattr rmdir };
+allow priv_app vfat:file rw_file_perms;
+allow priv_app vfat:file { create getattr };
+
+allow priv_app block_device:dir { getattr };
+allow priv_app proc_sysrq:file { getattr };
+allow priv_app proc_iomem:file { getattr };
+
+allow priv_app sysfs:dir r_dir_perms;
+allow priv_app sysfs:file r_file_perms;
+

--- a/rild.te
+++ b/rild.te
@@ -1,3 +1,5 @@
+binder_call(audioserver, rild)
+binder_call(rild, audioserver)
 binder_call(rild, mediaserver)
 binder_use(rild)
 binder_service(rild)

--- a/untrusted_app.te
+++ b/untrusted_app.te
@@ -1,5 +1,14 @@
 allow untrusted_app vfat:dir rw_dir_perms;
+allow untrusted_app vfat:dir create;
+allow untrusted_app vfat:file rw_file_perms;
 allow untrusted_app vfat:file create;
+allow untrusted_app vfat:dir { setattr rmdir };
 
+allow untrusted_app block_device:dir { getattr };
+allow untrusted_app proc_sysrq:file { getattr };
+allow untrusted_app proc_iomem:file { getattr };
+
+allow untrusted_app sysfs:dir r_dir_perms;
+allow untrusted_app sysfs:file r_file_perms;
 allow untrusted_app sysfs_zram:dir r_dir_perms;
 allow untrusted_app sysfs_zram:file r_file_perms;


### PR DESCRIPTION
avc: denied { call } for pid=871 comm="rild"
scontext=u:r:rild:s0 tcontext=u:r:audioserver:s0 tclass=binder permissive=0

avc: denied { read } for pid=3232
comm="com.cpuid.cpu_z" name="temp1_input" dev="sysfs" ino=36313
scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0
tclass=file permissive=0

avc: denied { setattr } for pid=2308 comm="MediaScannerSer" name="files"
dev="mmcblk1p1" ino=180 scontext=u:r:priv_app:s0:c512,c768
tcontext=u:object_r:vfat:s0 tclass=dir permissive=0

avc: denied { create } for pid=2292 comm=".apps.translate"
name="tmp_dir_should_be_removed" scontext=u:r:untrusted_app:s0:c512,c768
tcontext=u:object_r:vfat:s0:c512,c768 tclass=dir permissive=0

avc: denied { rmdir } for pid=2297 comm=".apps.translate"
name="tmp_dir_should_be_removed" dev="mmcblk1p1"
ino=80 scontext=u:r:untrusted_app:s0:c512,c768
tcontext=u:object_r:vfat:s0 tclass=dir permissive=0

avc: denied { getattr } for pid=4982 comm="me.twrp.twrpapp"
path="/proc/sysrq-trigger" dev="proc" ino=4026532499
scontext=u:r:untrusted_app:s0:c512,c768
tcontext=u:object_r:proc_sysrq:s0 tclass=file permissive=0

avc: denied { getattr } for pid=4778 comm="me.twrp.twrpapp" path="/proc/iomem"
dev="proc" ino=4026532425 scontext=u:r:untrusted_app:s0:c512,c768
tcontext=u:object_r:proc_iomem:s0 tclass=file permissive=0

avc: denied { getattr } for pid=5717 comm="df" path="/persist"
dev="mmcblk0p44" ino=2 scontext=u:r:untrusted_app:s0:c512,c768
tcontext=u:object_r:persist_file:s0 tclass=dir permissive=0