### PR TITLE
sepolicy: avoid chrome denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -231,6 +231,7 @@
 /sys/devices(/soc\.0)?/f9200000\.ssusb/power_supply/usb/current_max                            u:object_r:sysfs_thermal:s0
 /sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpuclk                            u:object_r:sysfs_thermal:s0
 /sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/max_gpuclk                        u:object_r:sysfs_thermal:s0
+/sys/devices(/soc\.0)?/fdb00000\.qcom,kgsl-3d0/kgsl/kgsl-3d0/reset_count                       u:object_r:sysfs_thermal:s0
 
 # Timekeep
 /sys/devices(/soc\.0)?/00-qcom,pm(8941|8950|8994)_rtc/rtc/rtc0/since_epoch                     u:object_r:sysfs_timekeep:s0


### PR DESCRIPTION
04-16 16:12:10.371  6947  6947 W CrGpuMain: type=1400 audit(0.0:21): avc: denied { read } for name=reset_count dev=sysfs ino=10940 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>