### PR TITLE
sepolicy: add bootstat selinux

### DIFF
--- a/bootstat.te
+++ b/bootstat.te
@@ -1,0 +1,1 @@
+allow bootstat rootfs:lnk_file getattr;


### PR DESCRIPTION
bootstat is looking for vendor partition or vendor symlink

04-20 11:36:45.569  3021  3021 W bootstat: type=1400 audit(0.0:4): avc: denied { getattr } for path=/vendor dev=rootfs ino=6256 scontext=u:r:bootstat:s0 tcontext=u:object_r:rootfs:s0 tclass=lnk_file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>