### PR TITLE
sepolicy: avoid 3.10 denials

### DIFF
--- a/kernel.te
+++ b/kernel.te
@@ -5,7 +5,7 @@ allow kernel tmpfs:dir create_dir_perms;
 allow kernel rootfs:file rx_file_perms;
 allow kernel block_device:blk_file rw_file_perms;
 allow kernel touchfusion_exec:file relabelto;
-
+allow kernel kernel:capability mknod;
 allow kernel self:socket create;
 
 domain_auto_trans(kernel, touchfusion_exec, touchfusion)

--- a/keystore.te
+++ b/keystore.te
@@ -1,3 +1,3 @@
 allow keystore tee_device:chr_file rw_file_perms;
-
+allow keystore firmware_file:dir search;
 allow keystore { firmware_file tee_prop }:file r_file_perms;


### PR DESCRIPTION
05-09 09:54:15.579    32    32 W kdevtmpfs: type=1400 audit(0.0:4): avc: denied { mknod } for capability=27 scontext=u:r:kernel:s0 tcontext=u:r:kernel:s0 tclass=capability permissive=0
05-09 10:36:34.149   489   489 W keystore: type=1400 audit(0.0:4): avc: denied { search } for name="/" dev="mmcblk0p3" ino=1 scontext=u:r:keystore:s0 tcontext=u:object_r:firmware_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>