### PR TITLE
sepolicy: fix settings denial

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -13,6 +13,7 @@ allow system_app timekeep_data_file:dir { create_dir_perms search };
 allow system_app timekeep_data_file:file create_file_perms;
 allow system_app media_rw_data_file:dir r_dir_perms;
 allow system_app fuse_device:filesystem getattr;
+allow system_app fingerprintd:binder call;
 
 # ExtendedSettings props
 allow system_app adbtcpes_prop:property_service set;


### PR DESCRIPTION
06-06 23:18:02.550  7457  7457 W com.android.settings: type=1400 audit(0.0:7): avc: denied { call } for comm=4173796E635461736B202339 scontext=u:r:system_app:s0 tcontext=u:r:fingerprintd:s0 tclass=binder permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>