### PR TITLE
sepolicy: avoid 3.10 denials

### DIFF
--- a/kernel.te
+++ b/kernel.te
@@ -1,5 +1,6 @@
 allow kernel device:dir create_dir_perms;
 allow kernel device:chr_file { create setattr getattr };
+allow kernel device:blk_file { create setattr };
 allow kernel tmpfs:file create_file_perms;
 allow kernel tmpfs:dir create_dir_perms;
 allow kernel rootfs:file rx_file_perms;

--- a/radio.te
+++ b/radio.te
@@ -1,1 +1,2 @@
 allow radio system_app_data_file:dir getattr;
+allow radio media_rw_data_file:dir search;

--- a/system_server.te
+++ b/system_server.te
@@ -16,6 +16,7 @@ use_per_mgr(system_server);
 allow system_server { persist_file system_app_data_file }:dir { open read search };
 allow system_server persist_file:file { getattr open write };
 allow system_server xlat_prop:file { getattr open read };
+allow system_server unlabeled:file unlink;
 
 r_dir_file(system_server, sysfs_addrsetup)
 r_dir_file(system_server, sysfs_pronto)


### PR DESCRIPTION
observed during factory reset on kugo

08-07 04:27:59.609  4606  4606 W Thread-20: type=1400 audit(0.0:4): avc: denied { unlink } for name=log dev=mmcblk0p35 ino=8197 scontext=u:r:system_server:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=0
08-07 04:27:59.609  4606  4606 W Thread-20: type=1400 audit(0.0:5): avc: denied { unlink } for name=.version dev=mmcblk0p35 ino=8198 scontext=u:r:system_server:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=0
08-07 04:27:59.609  4606  4606 W Thread-20: type=1400 audit(0.0:6): avc: denied { unlink } for name=recovery.fstab dev=mmcblk0p35 ino=8200 scontext=u:r:system_server:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=0
08-07 04:27:59.609  4606  4606 W Thread-20: type=1400 audit(0.0:7): avc: denied { unlink } for name=storage.fstab dev=mmcblk0p35 ino=8206 scontext=u:r:system_server:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=0
08-07 04:27:59.609  4606  4606 W Thread-20: type=1400 audit(0.0:8): avc: denied { unlink } for name=intent dev=mmcblk0p35 ino=8207 scontext=u:r:system_server:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=0

06-13 18:38:19.089  3418  3418 W Binder:3084_3: type=1400 audit(0.0:9): avc: denied { search } for name=data dev=mmcblk0p51 ino=971054 scontext=u:r:radio:s0 tcontext=u:object_r:media_rw_data_file:s0:c512,c768 tclass=dir permissive=0

08-07 04:59:57.849    32    32 W kdevtmpfs: type=1400 audit(0.0:5): avc: denied { create } for name="dm-0" scontext=u:r:kernel:s0 tcontext=u:object_r:device:s0 tclass=blk_file permissive=0
08-07 05:08:17.669    32    32 W kdevtmpfs: type=1400 audit(0.0:4): avc: denied { setattr } for name="dm-0" dev="devtmpfs" ino=21733 scontext=u:r:kernel:s0 tcontext=u:object_r:device:s0 tclass=blk_file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>