### PR TITLE
sepolicy: fix cam denial

### DIFF
--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -24,9 +24,8 @@ allow mm-qcamerad camera_data_file:file { create getattr open read write };
 allow mm-qcamerad camera_data_file:sock_file create_file_perms;
 allow mm-qcamerad { graphics_device gpu_device video_device }:chr_file rw_file_perms;
 allow mm-qcamerad sysfs_video:file r_file_perms;
-allow mm-qcamerad { cameraserver surfaceflinger }:fd use;
+allow mm-qcamerad { cameraserver mediaserver surfaceflinger }:fd use;
 allow mm-qcamerad camera_prop:property_service set;
 allow mm-qcamerad property_socket:sock_file write;
 allow mm-qcamerad init:unix_stream_socket connectto;
-
-allow mm-qcamerad mediaserver:fd use;
+allow mm-qcamerad debugfs:dir read;


### PR DESCRIPTION
06-19 21:15:49.791  6625  6625 W CAM_mct_freeze: type=1400 audit(0.0:10): avc: denied { read } for name=clk dev=debugfs ino=1112 scontext=u:r:mm-qcamerad:s0 tcontext=u:object_r:debugfs:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>