### PR TITLE
[SEPOLICY] cnss-daemon: Allow netlink_socket read

### DIFF
--- a/cnss-daemon.te
+++ b/cnss-daemon.te
@@ -17,7 +17,7 @@ allow cnss-daemon self:socket create_socket_perms;
 allow cnss-daemon self:capability { setgid setuid net_admin};
 allow cnss-daemon self:netlink_generic_socket { bind create getattr setopt };
 allow cnss-daemon self:netlink_route_socket { bind create read };
-allow cnss-daemon self:netlink_socket { bind create };
+allow cnss-daemon self:netlink_socket { bind create read };
 allow cnss-daemon self:udp_socket { create ioctl };
 
 allow cnss-daemon servicemanager:binder call;


### PR DESCRIPTION
The daemon requires reading the same netlink sockets that it creates.