### PR TITLE
sepolicy: fix netmgrd denials

### DIFF
--- a/netmgrd.te
+++ b/netmgrd.te
@@ -26,8 +26,9 @@ allow netmgrd netmgrd:netlink_socket { write read create bind };
 allow netmgrd netmgrd:socket { create ioctl };
 allow netmgrd netmgrd:netlink_route_socket { setopt getattr write nlmsg_write };
 allow netmgrd self:netlink_generic_socket { bind create write};
-allow netmgrd system_data_file:dir { add_name write };
-allow netmgrd system_data_file:file { open };
+allow netmgrd netmgr_data_file:dir { add_name write };
+allow netmgrd netmgr_data_file:file { open create };
+
 rw_dir_file(netmgrd, netmgr_data_file)
 
 qmux_socket(netmgrd);


### PR DESCRIPTION
02-19 06:40:52.299   536   536 W netmgrd : type=1400 audit(0.0:4): avc: denied { create } for name=log.txt scontext=u:r:netmgrd:s0 tcontext=u:object_r:netmgr_data_file:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>