### PR TITLE
sepolicy: fix fpc denials

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -12,6 +12,7 @@ allow system_app network_management_service:service_manager find;
 allow system_app timekeep_data_file:dir { create_dir_perms search };
 allow system_app timekeep_data_file:file create_file_perms;
 allow system_app media_rw_data_file:dir r_dir_perms;
+allow system_app fingerprintd:binder call;
 
 # ExtendedSettings props
 allow system_app adbtcpes_prop:property_service set;


### PR DESCRIPTION
06-30 15:05:41.156  3988  3988 W com.android.settings: type=1400 audit(0.0:15): avc: denied { call } for comm=4173796E635461736B202333 scontext=u:r:system_app:s0 tcontext=u:r:fingerprintd:s0 tclass=binder permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>