### PR TITLE
sepolicy: fix adbd denials

### DIFF
--- a/adbd.te
+++ b/adbd.te
@@ -1,0 +1,1 @@
+allow adbd security_file:dir search;


### PR DESCRIPTION
07-03 02:01:10.285 14331 14331 W /sbin/adbd: type=1400 audit(0.0:6): avc: denied { search } for comm=73657276696365203430 name=security dev=mmcblk0p54 ino=848641 scontext=u:r:adbd:s0 tcontext=u:object_r:security_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>