### PR TITLE
sepolicy: fix netd denials

### DIFF
--- a/netd.te
+++ b/netd.te
@@ -1,4 +1,5 @@
 allow netd netd:capability sys_module;
 allow netd kernel:system module_request;
+allow netd untrusted_app:unix_stream_socket { read write };
 
 binder_use(netd);


### PR DESCRIPTION
07-03 01:55:51.748  1058  1058 W netd    : type=1400 audit(0.0:4): avc: denied { read write } for path=socket:[127189] dev=sockfs ino=127189 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=unix_stream_socket permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>