### PR TITLE
sepolicy: fix mtp denials

### DIFF
--- a/priv_app.te
+++ b/priv_app.te
@@ -8,7 +8,7 @@ allow priv_app vfat:dir {
     write
 };
 
-allow priv_app vfat:file { create getattr setattr };
+allow priv_app vfat:file { create getattr setattr unlink };
 
 r_dir_file(priv_app, device)
 


### PR DESCRIPTION
07-05 18:14:37.887  7371  7371 W MtpServer: type=1400 audit(0.0:14): avc: denied { unlink } for name=48512031343720627920566974742E617669 dev=mmcblk1p1 ino=76 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:vfat:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>