### PR TITLE
sepolicy: let ES call soft reboot (bootanimation) for DRS

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -17,5 +17,5 @@ allow system_app fingerprintd:binder call;
 # ExtendedSettings props
 allow system_app adbtcpes_prop:property_service set;
 allow system_app camera_prop:property_service set;
-
+allow system_app boot_animation_prop:property_service set;
 rw_dir_file(system_app, sysfs_graphics)


### PR DESCRIPTION
[  121.476520] init: avc:  denied  { set } for property=debug.sf.nobootanimation pid=5265 uid=1000 gid=1000 scontext=u:r:system_app:s0 tcontext=u:object_r:boot_animation_prop:s0 tclass=property_service permissive=0