### PR TITLE
sepolicy: fix priv_app denial

### DIFF
--- a/priv_app.te
+++ b/priv_app.te
@@ -18,6 +18,7 @@ allow priv_app {
     system_app_data_file
     nfc_data_file
     bluetooth_data_file
+    storage_stub_file
 }:dir getattr;
 
 allow priv_app {


### PR DESCRIPTION
07-31 21:21:52.330 29683 29683 W d.process.media: type=1400 audit(0.0:1171): avc: denied { getattr } for path=/storage/3FE0-1616 dev=tmpfs ino=1480397 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:storage_stub_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>