### PR TITLE
[SEPOLICY] Remove domain_deprecated from all units

### DIFF
--- a/adbd.te
+++ b/adbd.te
@@ -1,1 +1,0 @@
-allow adbd security_file:dir search;

--- a/addrsetup.te
+++ b/addrsetup.te
@@ -1,4 +1,4 @@
-type addrsetup, domain, domain_deprecated;
+type addrsetup, domain;
 type addrsetup_exec, exec_type, file_type;
 
 # Started by init

--- a/addrsetup.te
+++ b/addrsetup.te
@@ -14,4 +14,4 @@ allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
 unix_socket_connect(addrsetup, tad, tad)
 
-allow addrsetup urandom_device:file read;
+allow addrsetup random_device:file read;

--- a/debuggerd.te
+++ b/debuggerd.te
@@ -1,2 +1,2 @@
-allow debuggerd urandom_device:file { getattr open read };
+allow debuggerd random_device:file { getattr open read };
 

--- a/fsck.te
+++ b/fsck.te
@@ -1,2 +1,2 @@
-allow fsck urandom_device:file getattr;
+allow fsck random_device:file getattr;
 allow fsck block_device:blk_file { getattr ioctl };

--- a/irsc_util.te
+++ b/irsc_util.te
@@ -1,4 +1,4 @@
-type irsc_util, domain, domain_deprecated;
+type irsc_util, domain;
 type irsc_util_exec, exec_type, file_type;
 
 init_daemon_domain(irsc_util)

--- a/lmkd.te
+++ b/lmkd.te
@@ -1,4 +1,4 @@
 allow lmkd sysfs_lowmemorykiller:dir search;
 
-allow lmkd urandom_device:file { getattr open read };
+allow lmkd random_device:file { getattr open read };
 

--- a/logd.te
+++ b/logd.te
@@ -1,2 +1,2 @@
-allow logd urandom_device:file { getattr open read };
+allow logd random_device:file { getattr open read };
 

--- a/mlog_qmi.te
+++ b/mlog_qmi.te
@@ -1,4 +1,4 @@
-type mlog_qmi, domain, domain_deprecated;
+type mlog_qmi, domain;
 type mlog_qmi_exec, exec_type, file_type;
 
 # Started by init

--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -1,4 +1,4 @@
-type mm-qcamerad, domain, domain_deprecated;
+type mm-qcamerad, domain;
 type mm-qcamerad_exec, exec_type, file_type;
 
 # Started by init

--- a/msm_irqbalanced.te
+++ b/msm_irqbalanced.te
@@ -1,4 +1,4 @@
-type msm_irqbalanced, domain, domain_deprecated;
+type msm_irqbalanced, domain;
 type msm_irqbalanced_exec, exec_type, file_type;
 
 init_daemon_domain(msm_irqbalanced)

--- a/netmgrd.te
+++ b/netmgrd.te
@@ -1,4 +1,4 @@
-type netmgrd, domain, domain_deprecated;
+type netmgrd, domain;
 type netmgrd_exec, exec_type, file_type;
 
 net_domain(netmgrd)

--- a/pad_controller.te
+++ b/pad_controller.te
@@ -1,4 +1,4 @@
-type pad_controller, domain, domain_deprecated;
+type pad_controller, domain;
 type pad_controller_exec, exec_type, file_type;
 
 init_daemon_domain(pad_controller)

--- a/peripheral_manager.te
+++ b/peripheral_manager.te
@@ -1,4 +1,4 @@
-type per_mgr, domain, domain_deprecated;
+type per_mgr, domain;
 type per_mgr_exec, exec_type, file_type;
 
 init_daemon_domain(per_mgr);

--- a/qmuxd.te
+++ b/qmuxd.te
@@ -1,4 +1,4 @@
-type qmuxd, domain, domain_deprecated;
+type qmuxd, domain;
 type qmuxd_exec, exec_type, file_type;
 
 net_domain(qmuxd)

--- a/rmt_storage.te
+++ b/rmt_storage.te
@@ -1,4 +1,4 @@
-type rmt_storage, domain, domain_deprecated;
+type rmt_storage, domain;
 type rmt_storage_exec, exec_type, file_type;
 
 init_daemon_domain(rmt_storage)

--- a/sct.te
+++ b/sct.te
@@ -1,4 +1,4 @@
-type sct, domain, domain_deprecated;
+type sct, domain;
 type sct_exec, exec_type, file_type;
 
 # Started by init

--- a/sensors.te
+++ b/sensors.te
@@ -1,4 +1,4 @@
-type sensors, domain, domain_deprecated;
+type sensors, domain;
 type sensors_exec, exec_type, file_type;
 
 init_daemon_domain(sensors)

--- a/ta_qmi.te
+++ b/ta_qmi.te
@@ -1,4 +1,4 @@
-type ta_qmi, domain, domain_deprecated;
+type ta_qmi, domain;
 type ta_qmi_exec, exec_type, file_type;
 
 # Started by init

--- a/tad.te
+++ b/tad.te
@@ -1,4 +1,4 @@
-type tad, domain, domain_deprecated;
+type tad, domain;
 type tad_exec, exec_type, file_type;
 
 # Started by init

--- a/tfa_amp.te
+++ b/tfa_amp.te
@@ -1,4 +1,4 @@
-type tfa_amp, domain, domain_deprecated;
+type tfa_amp, domain;
 type tfa_amp_exec, exec_type, file_type;
 
 # Started by init

--- a/thermanager.te
+++ b/thermanager.te
@@ -1,4 +1,4 @@
-type thermanager, domain, domain_deprecated;
+type thermanager, domain;
 type thermanager_exec, exec_type, file_type;
 
 # Started by init

--- a/timekeep.te
+++ b/timekeep.te
@@ -1,4 +1,4 @@
-type timekeep, domain, domain_deprecated;
+type timekeep, domain;
 type timekeep_exec, exec_type, file_type;
 
 # Started by init

--- a/touchfusion.te
+++ b/touchfusion.te
@@ -1,4 +1,4 @@
-type touchfusion, domain, domain_deprecated;
+type touchfusion, domain;
 type touchfusion_exec, exec_type, file_type;
 
 init_daemon_domain(touchfusion)

--- a/ueventd.te
+++ b/ueventd.te
@@ -18,6 +18,6 @@ allow ueventd {
 }:file w_file_perms;
 
 allow ueventd device:file relabelfrom;
-allow ueventd urandom_device:file { relabelto setattr };
+allow ueventd random_device:file { relabelto setattr };
 allow ueventd vfat:file { open read };
 

--- a/vold.te
+++ b/vold.te
@@ -1,4 +1,4 @@
-allow vold urandom_device:file { getattr open read };
+allow vold random_device:file { getattr open read };
 allow vold storage_stub_file:dir rw_dir_perms;
 
 allow vold tee_prop:file { r_file_perms };

--- a/wcnss_service.te
+++ b/wcnss_service.te
@@ -1,4 +1,4 @@
-type wcnss_service, domain, domain_deprecated;
+type wcnss_service, domain;
 type wcnss_service_exec, exec_type, file_type;
 
 init_daemon_domain(wcnss_service)


### PR DESCRIPTION
This is deprecated and, since Android 8.0, removed.
NOTE: All units touched by this commits WILL NEED to be fixed
properly.