### PR TITLE
sepolicy: allow thermanager read lnk_file

### DIFF
--- a/thermanager.te
+++ b/thermanager.te
@@ -5,6 +5,7 @@ type thermanager_exec, exec_type, file_type;
 init_daemon_domain(thermanager)
 
 allow thermanager self:capability dac_override;
+allow thermanager sysfs_battery_supply:lnk_file read;
 
 # Hotplugging destroys sysfs so they lose all contexts when recreated.
 rw_dir_file(thermanager, sysfs)


### PR DESCRIPTION
on 4.4 smb symlinks from /sys/class/power_supply/battery/* to driver, allow thermanager reads it

03-26 17:30:18.719   543   543 W thermanager: type=1400 audit(0.0:4): avc: denied { read } for name=battery dev=sysfs ino=38037 scontext=u:r:thermanager:s0 tcontext=u:object_r:sysfs_battery_supply:s0 tclass=lnk_file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>