### PR TITLE
Remove dev block nodes from common file_contexts

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -21,8 +21,6 @@
 /dev/jpeg[0-9]*                                 u:object_r:video_device:s0
 /dev/v4l-subdev.*                               u:object_r:video_device:s0
 /dev/video.*                                    u:object_r:video_device:s0
-/dev/block/mmcblk1                              u:object_r:sd_device:s0
-/dev/block/mmcblk1p1                            u:object_r:sd_device:s0
 /dev/ramdump_.*                                 u:object_r:ramdump_device:s0
 /dev/ipa                                        u:object_r:ipa_dev:s0
 /dev/wwan_ioctl                                 u:object_r:ipa_dev:s0
@@ -39,80 +37,6 @@
 /dev/subsys_modem                               u:object_r:subsys_modem_device:s0
 /dev/tfa98xx                                    u:object_r:audio_device:s0
 /dev/ttyHS0                                     u:object_r:hci_attach_dev:s0
-
-###################################
-# Dev block nodes
-#
-/dev/block/mmcblk0                                             u:object_r:root_block_device:s0
-/dev/block/mmcblk0rpmb                                         u:object_r:rpmb_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/modemst1     u:object_r:modem_efs_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/modemst1     u:object_r:modem_efs_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/modemst1    u:object_r:modem_efs_partition_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/modemst1                       u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/modemst1                                 u:object_r:modem_efs_partition_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/modemst2     u:object_r:modem_efs_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/modemst2     u:object_r:modem_efs_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/modemst2    u:object_r:modem_efs_partition_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/modemst2                       u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/modemst2                                 u:object_r:modem_efs_partition_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/fsg          u:object_r:modem_efs_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/fsg          u:object_r:modem_efs_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/fsg         u:object_r:modem_efs_partition_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/fsg                            u:object_r:modem_efs_partition_device:s0
-/dev/block/bootdevice/by-name/fsg                                      u:object_r:modem_efs_partition_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/ssd          u:object_r:ssd_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/ssd          u:object_r:ssd_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/ssd         u:object_r:ssd_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/ssd                            u:object_r:ssd_device:s0
-/dev/block/bootdevice/by-name/ssd                                      u:object_r:ssd_device:s0
-
-/dev/block/mmcblk0p1                                                   u:object_r:trim_area_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/TA           u:object_r:trim_area_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/TA           u:object_r:trim_area_partition_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/TA          u:object_r:trim_area_partition_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/TA                             u:object_r:trim_area_partition_device:s0
-/dev/block/bootdevice/by-name/TA                                       u:object_r:trim_area_partition_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/userdata     u:object_r:userdata_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/userdata     u:object_r:userdata_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/userdata    u:object_r:userdata_block_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/userdata                       u:object_r:userdata_block_device:s0
-/dev/block/bootdevice/by-name/userdata                                 u:object_r:userdata_block_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/boot         u:object_r:boot_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/boot         u:object_r:boot_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/boot        u:object_r:boot_block_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/boot                           u:object_r:boot_block_device:s0
-/dev/block/bootdevice/by-name/boot                                     u:object_r:boot_block_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/FOTAKernel   u:object_r:recovery_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/FOTAKernel   u:object_r:recovery_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/FOTAKernel  u:object_r:recovery_block_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/FOTAKernel                     u:object_r:recovery_block_device:s0
-/dev/block/bootdevice/by-name/FOTAKernel                               u:object_r:recovery_block_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/cache        u:object_r:cache_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/cache        u:object_r:cache_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/cache       u:object_r:cache_block_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/cache                          u:object_r:cache_block_device:s0
-/dev/block/bootdevice/by-name/cache                                    u:object_r:cache_block_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/apps_log     u:object_r:misc_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/apps_log     u:object_r:misc_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/misc        u:object_r:misc_block_device:s0
-/dev/block/platform/msm_sdcc\.1/by-name/apps_log                       u:object_r:misc_block_device:s0
-/dev/block/bootdevice/by-name/apps_log                                 u:object_r:misc_block_device:s0
-/dev/block/bootdevice/by-name/misc                                     u:object_r:misc_block_device:s0
-
-/dev/block/platform(/soc\.0|/soc)?/7464900\.sdhci/by-name/persist      u:object_r:persist_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/7824900\.sdhci/by-name/persist      u:object_r:persist_block_device:s0
-/dev/block/platform(/soc\.0|/soc)?/f9824900\.sdhci/by-name/persist     u:object_r:persist_block_device:s0
-
-/dev/block/zram0                                                       u:object_r:swap_block_device:s0
 
 ###################################
 # Dev socket nodes


### PR DESCRIPTION
We have moved these context declarations to platform-specific
repositories.