### PR TITLE
sepolicy: Fix bluetooth, WiFi and tee denials

### DIFF
--- a/bluetooth.te
+++ b/bluetooth.te
@@ -5,6 +5,7 @@ allow bluetooth sysfs:file w_file_perms;
 allow bluetooth smd_device:chr_file rw_file_perms;
 
 allow bluetooth device:chr_file { ioctl };
+allow bluetooth btpower_device:chr_file { rw_file_perms };
 
 allow bluetooth start_hci_filter:unix_stream_socket connectto;
 allow bluetooth storage_stub_file:dir getattr;

--- a/cnss-daemon.te
+++ b/cnss-daemon.te
@@ -5,9 +5,6 @@ init_daemon_domain(cnss-daemon)
 
 allow cnss-daemon proc_net:file rw_file_perms;
 
-allow cnss-daemon sysfs:dir r_dir_perms;
-allow cnss-daemon sysfs:file { open read };
-
 allow cnss-daemon rootfs:lnk_file getattr;
 
 allow cnss-daemon per_mgr:binder { call transfer };
@@ -15,10 +12,11 @@ allow cnss-daemon per_mgr_service:service_manager find;
 
 allow cnss-daemon self:socket create_socket_perms;
 allow cnss-daemon self:capability { setgid setuid net_admin};
-allow cnss-daemon self:netlink_generic_socket { bind create getattr setopt };
-allow cnss-daemon self:netlink_route_socket { bind create read };
-allow cnss-daemon self:netlink_socket { bind create read };
-allow cnss-daemon self:udp_socket { create ioctl };
+allow cnss-daemon self:netlink_generic_socket { create_socket_perms };
+allow cnss-daemon self:netlink_route_socket { create_socket_perms };
+allow cnss-daemon self:netlink_socket { create_socket_perms };
+allow cnss-daemon self:udp_socket { create_socket_perms };
 
 allow cnss-daemon servicemanager:binder call;
 
+allow cnss-daemon sysfs_subsys:file { r_file_perms };

--- a/device.te
+++ b/device.te
@@ -62,3 +62,5 @@ type avtimer_device, dev_type;
 type subsys_modem_device, dev_type;
 type trim_area_partition_device, dev_type;
 type persist_block_device, dev_type;
+
+type btpower_device, dev_type;

--- a/file_contexts
+++ b/file_contexts
@@ -3,6 +3,7 @@
 #
 /dev/adsprpc-smd                                u:object_r:qdsp_device:s0
 /dev/brcm_bt_drv                                u:object_r:hci_attach_dev:s0
+/dev/btpower                                    u:object_r:btpower_device:s0
 /dev/cpu_dma_latency                            u:object_r:device_latency:s0
 /dev/diag                                       u:object_r:diag_device:s0
 /dev/kgsl-3d0                                   u:object_r:gpu_device:s0
@@ -164,9 +165,14 @@
 
 # Subsystem
 /sys/devices(/soc\.0|/soc)?/(fe200000|c200000)\.qcom,lpass/subsys1/name                             u:object_r:sysfs_subsys:s0
-/sys/devices(/soc\.0|/soc)?/fc880000\.qcom,mss/subsys2/name                                         u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/(fc880000|4080000)\.qcom,mss/subsys(2|6)/name                           u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/1d0101c\.qcom,spss/subsys2/name                                         u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0|/soc)?/(fc880000|4080000)\.qcom,mss/subsys3/name                               u:object_r:sysfs_subsys:s0
-/sys/devices(/soc\.0|/soc)?/(fdce0000|1de0000)\.qcom,venus/subsys0/name                             u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/(fdce0000|1de0000|cce0000)\.qcom,venus/subsys(0|1)/name                 u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/soc\:qcom,ipa_fws@1e08000/subsys0/name                                  u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/soc\:qcom,kgsl-hyp/subsys3/name                                         u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/17300000\.qcom,lpass/subsys4/name                                       u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/5c00000\.qcom,ssc/subsys5/name                                          u:object_r:sysfs_subsys:s0
 
 # Thermal
 /sys/devices(/soc\.0|/soc)?/02-qcom,qpnp-smbcharger/power_supply/battery/charging_enabled           u:object_r:sysfs_thermal:s0

--- a/pd_mapper.te
+++ b/pd_mapper.te
@@ -10,3 +10,5 @@ allow pd_mapper firmware_file:file { open read };
 allow pd_mapper self:capability { net_bind_service setgid setpcap setuid };
 allow pd_mapper self:socket { bind create ioctl read write };
 
+allow pd_mapper sysfs_subsys:file { r_file_perms };
+allow pd_mapper system_file:dir { r_dir_perms };

--- a/property_contexts
+++ b/property_contexts
@@ -11,4 +11,7 @@ service.pad2.control.result   u:object_r:sys_pad_prop:s0
 ril.pad.force_calib.start     u:object_r:radio_prop:s0
 ril.pad.force_calib.result    u:object_r:radio_prop:s0
 
+wc_transport.                 u:object_r:bluetooth_prop:s0
+persist.bluetooth.a4wp        u:object_r:bluetooth_prop:s0
+
 adb.network.port.es           u:object_r:adbtcpes_prop:s0

--- a/start_hci_filter.te
+++ b/start_hci_filter.te
@@ -17,3 +17,4 @@ allow start_hci_filter init:unix_stream_socket connectto;
 allow start_hci_filter property_socket:sock_file write;
 allow start_hci_filter rootfs:lnk_file getattr;
 allow start_hci_filter sysfs_wake_lock:file { append open };
+allow start_hci_filter bluetooth_prop:property_service set;

--- a/tee.te
+++ b/tee.te
@@ -1,4 +1,4 @@
 allow tee device:chr_file { ioctl setattr };
 allow tee device:dir { open read };
-allow tee self:capability { chown sys_rawio };
+allow tee self:capability { chown sys_rawio sys_admin };
 allow tee sg_device:chr_file { ioctl open read setattr write };


### PR DESCRIPTION
[*] Rework sysfs handling in cnss-deamon and pd_mapper, only allow access to subsystems
[*] Fix denials to bluetooth properties and dev/btpower
[*] allow tee system_admin permissions