### PR TITLE
sepolicy: fix system_server denials

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -22,7 +22,7 @@ allow system_server storage_stub_file:dir getattr;
 rw_dir_file(system_server, powerhal_data_file)
 allow system_server powerhal_data_file:sock_file create_file_perms;
 
-allow system_server media_rw_data_file:dir getattr;
+allow system_server media_rw_data_file:dir r_dir_perms;
 
 allow system_server sensors_persist_file:dir search;
 allow system_server sensors_persist_file:file { open read };


### PR DESCRIPTION
08-13 18:29:16.560  2633  2633 W Binder:776_8: type=1400 audit(0.0:107): avc: denied { read open } for path=/data/media/0/Android/data dev=mmcblk0p51 ino=971054 scontext=u:r:system_server:s0 tcontext=u:object_r:media_rw_data_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>