### PR TITLE
sepolicy: avoid light denials

### DIFF
--- a/hal_light_default.te
+++ b/hal_light_default.te
@@ -1,2 +1,1 @@
-allow hal_light_default sysfs:file r_file_perms;
-
+allow hal_light_default sysfs:file rw_file_perms;


### PR DESCRIPTION
09-17 13:28:44.987   546   546 W light@2.0-servi: type=1400 audit(0.0:1005): avc: denied { write } for name=brightness dev=sysfs ino=32235 scontext=u:r:hal_light_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>