### PR TITLE
sepolicy: let priv apps find hwservice_manager

### DIFF
--- a/priv_app.te
+++ b/priv_app.te
@@ -35,3 +35,4 @@ allow priv_app unlabeled:dir r_dir_perms;
 allow priv_app unlabeled:file r_file_perms;
 
 allow priv_app debugfs_kgsl:dir search;
+allow priv_app hal_memtrack_hwservice:hwservice_manager find;


### PR DESCRIPTION
needed by apps like GMS (GoogleApp)

Signed-off-by: David Viteri <davidteri91@gmail.com>