### PR TITLE
sepolicy: avoid cam denials

### DIFF
--- a/hal_camera_default.te
+++ b/hal_camera_default.te
@@ -8,6 +8,7 @@ allow hal_camera_default debugfs_kgsl:dir search;
 allow hal_camera_default qdisplay_service:service_manager find;
 
 binder_call(hal_camera_default, vndservicemanager)
+binder_call(hal_camera_default, hal_graphics_composer_default)
 
 # PowerHAL
 allow hal_camera_default powerhal_data_file:dir search;


### PR DESCRIPTION
needed by binderized cam via manifest.xml

09-17 14:56:21.518   966   966 W HwBinder:554_1: type=1400 audit(0.0:666): avc: denied { call } for scontext=u:r:hal_camera_default:s0 tcontext=u:r:hal_graphics_composer_default:s0 tclass=binder permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>