### PR TITLE
sepolicy: avoid GNSS denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -138,7 +138,7 @@
 # Bluetooth
 /sys/devices(/soc\.0|/soc)?/bluesleep\.(81|89)/rfkill/rfkill0/state            u:object_r:sysfs_bluetooth_writable:s0
 /sys/devices(/soc\.0|/soc)?/bcm43xx.([0-9])+/rfkill/rfkill[0-9](/.*)?          u:object_r:sysfs_bluetooth_writable:s0
-/sys/devices(/soc\.0|/soc)?/soc:bcm43xx/rfkill/rfkill0/state                   u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices(/soc\.0|/soc)?/soc\:bcm43xx/rfkill/rfkill0/state                  u:object_r:sysfs_bluetooth_writable:s0
 
 # Storage
 /sys/devices(/soc\.0|/soc)?/(fd80000|0)?\.qcom,rmtfs_sharedmem/uio/uio0/name                        u:object_r:sysfs_rmt_storage:s0
@@ -151,6 +151,7 @@
 /sys/devices(/soc\.0|/soc)?/(fc880000|4080000)\.qcom,mss(/.*)?                                      u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0|/soc)?/1d0101c\.qcom,spss(/.*)?                                                u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0|/soc)?/(fdce0000|1de0000|cce0000)\.qcom,venus(/.*)?                            u:object_r:sysfs_subsys:s0
+/sys/devices(/soc\.0|/soc)?/soc\:qcom,cpubw(/.*)?                                                   u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0|/soc)?/soc\:qcom,ipa_fws@1e08000(/.*)?                                         u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0|/soc)?/soc\:qcom,kgsl-hyp(/.*)?                                                u:object_r:sysfs_subsys:s0
 /sys/devices(/soc\.0|/soc)?/5c00000\.qcom,ssc(/.*)?                                                 u:object_r:sysfs_subsys:s0

--- a/file_contexts
+++ b/file_contexts
@@ -139,6 +139,7 @@
 /sys/devices(/soc\.0|/soc)?/bluesleep\.(81|89)/rfkill/rfkill0/state            u:object_r:sysfs_bluetooth_writable:s0
 /sys/devices(/soc\.0|/soc)?/bcm43xx.([0-9])+/rfkill/rfkill[0-9](/.*)?          u:object_r:sysfs_bluetooth_writable:s0
 /sys/devices(/soc\.0|/soc)?/soc\:bcm43xx/rfkill/rfkill0/state                  u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices/bt_wcn3990/rfkill/rfkill0/state                                   u:object_r:sysfs_bluetooth_writable:s0
 
 # Storage
 /sys/devices(/soc\.0|/soc)?/(fd80000|0)?\.qcom,rmtfs_sharedmem/uio/uio0/name                        u:object_r:sysfs_rmt_storage:s0

--- a/hal_bluetooth_default.te
+++ b/hal_bluetooth_default.te
@@ -1,2 +1,3 @@
 allow hal_bluetooth_default sysfs_bluetooth_writable:file w_file_perms;
 allow hal_bluetooth_default bluetooth_data_file:dir search;
+allow hal_bluetooth_default start_hci_filter:unix_stream_socket connectto;

--- a/hal_gnss_default.te
+++ b/hal_gnss_default.te
@@ -1,0 +1,24 @@
+allow hal_gnss_default vndbinder_device:chr_file rw_file_perms;
+allow hal_gnss_default sysfs:dir r_dir_perms;
+allow hal_gnss_default sysfs:file r_file_perms;
+allow hal_gnss_default self:socket { create read write ioctl } ;
+allowxperm hal_gnss_default self:socket ioctl { IPC_ROUTER_IOCTL_BIND_CONTROL_PORT
+                                                IPC_ROUTER_IOCTL_LOOKUP_SERVER } ;
+allow hal_gnss_default self:netlink_generic_socket { create bind read };
+allow hal_gnss_default sysfs_subsys:dir search;
+allow hal_gnss_default netmgrd_socket:dir search;
+allow hal_gnss_default sysfs_subsys:file r_file_perms;
+allow hal_gnss_default sysfs_subsys:dir r_dir_perms;
+
+# Most HALs are not allowed to use network sockets. Qcom library
+# libqdi is used across multiple processes which are clients of
+# netmgrd including the GNSS HAL. libqdi first attempts to get the network
+# interface using an IOCTL on a UDP INET socket, which isn't allowed here.
+# If that fails, it falls back to using libc's if_nameindex() which requires
+# a netlink route socket, which HALs may use. Due to the initial
+# attempt to use a UDP socket, we still see a selinux denial,
+# but it is safe to ignore.
+# TODO (b/37730994) Remove udp_socket requirement from
+# libqdi and have all its clients use netlink route
+# sockets.
+dontaudit hal_gnss_default self:udp_socket create;

--- a/start_hci_filter.te
+++ b/start_hci_filter.te
@@ -10,7 +10,7 @@ allow start_hci_filter proc_sysrq:file rw_file_perms;
 get_prop(start_hci_filter, bluetooth_prop)
 
 allow start_hci_filter bluetooth_data_file:dir w_dir_perms;
-allow start_hci_filter bluetooth_data_file:file rw_file_perms;
+allow start_hci_filter bluetooth_data_file:file create_file_perms;
 allow start_hci_filter bt_firmware_file:dir r_dir_perms;
 allow start_hci_filter bt_firmware_file:file r_file_perms;
 allow start_hci_filter hci_attach_dev:chr_file { ioctl open read write };


### PR DESCRIPTION
let Global Navigation Satellite Systems (GNSS) read & write into /dev/vndbinder

09-17 21:24:13.959  6062  6062 W android.hardwar: type=1400 audit(0.0:1938): avc: denied { read write } for name="vndbinder" dev="tmpfs" ino=10923 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:vndbinder_device:s0 tclass=chr_file permissive=0
09-17 21:37:02.229   635   635 W gnss@1.0-servic: type=1400 audit(0.0:26): avc: denied { read } for name="devices" dev="sysfs" ino=29502 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=0
09-17 21:37:02.244  1336  1336 W Loc_hal_worker: type=1400 audit(0.0:35): avc: denied { create } for scontext=u:r:hal_gnss_default:s0 tcontext=u:r:hal_gnss_default:s0 tclass=socket permissive=0
09-17 21:47:34.436  1342  1342 W Loc_hal_worker: type=1400 audit(0.0:2246398): avc: denied { ioctl } for path="socket:[20745]" dev="sockfs" ino=20745 ioctlcmd=c302 scontext=u:r:hal_gnss_default:s0 tcontext=u:r:hal_gnss_default:s0 tclass=socket permissive=0
09-17 22:30:12.333  1341  1341 W Loc_hal_worker: type=1400 audit(0.0:27): avc: denied { read } for name="name" dev="sysfs" ino=32525 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0
09-17 22:31:02.012  2802  2802 W Loc_hal_worker: type=1400 audit(0.0:92): avc: denied { create } for scontext=u:r:hal_gnss_default:s0 tcontext=u:r:hal_gnss_default:s0 tclass=netlink_generic_socket permissive=0
09-17 22:40:54.332  3934  3934 W Loc_hal_worker: type=1400 audit(0.0:156): avc: denied { search } for name="soc:qcom,kgsl-hyp" dev="sysfs" ino=22153 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:sysfs_subsys:s0 tclass=dir permissive=0
09-17 22:40:40.656  3490  3490 W Loc_hal_worker: type=1400 audit(0.0:135): avc: denied { bind } for scontext=u:r:hal_gnss_default:s0 tcontext=u:r:hal_gnss_default:s0 tclass=netlink_generic_socket permissive=0
09-17 22:47:57.829  1358  1358 W Loc_hal_worker: type=1400 audit(0.0:84): avc: denied { search } for name="netmgr" dev="tmpfs" ino=11002 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:netmgrd_socket:s0 tclass=dir permissive=0
09-17 22:54:44.966   633   633 W gnss@1.0-servic: type=1400 audit(0.0:26): avc: denied { read } for name="name" dev="sysfs" ino=32571 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:sysfs_subsys:s0 tclass=file permissive=0

udp_socket donoaudit see https://android.googlesource.com/device/google/marlin/+/209b465e277c15a0344d99790300583515c5d965

Signed-off-by: David Viteri <davidteri91@gmail.com>