### PR TITLE
sepolicy: more maple denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -131,15 +131,16 @@
 /sys/devices(/soc\.0|/soc)?/fpc1145\.105/irq                                        u:object_r:sysfs_fingerprintd_writable:s0
 
 # Modules
-/sys/module/cpu_boost(/.*)?                                               u:object_r:sysfs_devices_system_cpu:s0
-/sys/module/lpm_levels/parameters/sleep_disabled                          u:object_r:sysfs_power_management:s0
-/sys/module/msm_performance(/.*)?                                         u:object_r:sysfs_performance:s0
+/sys/module/cpu_boost(/.*)?                                                         u:object_r:sysfs_devices_system_cpu:s0
+/sys/module/lpm_levels/parameters/sleep_disabled                                    u:object_r:sysfs_power_management:s0
+/sys/module/msm_performance(/.*)?                                                   u:object_r:sysfs_performance:s0
 
 # Bluetooth
-/sys/devices(/soc\.0|/soc)?/bluesleep\.(81|89)/rfkill/rfkill0/state            u:object_r:sysfs_bluetooth_writable:s0
-/sys/devices(/soc\.0|/soc)?/bcm43xx.([0-9])+/rfkill/rfkill[0-9](/.*)?          u:object_r:sysfs_bluetooth_writable:s0
-/sys/devices(/soc\.0|/soc)?/soc\:bcm43xx/rfkill/rfkill0/state                  u:object_r:sysfs_bluetooth_writable:s0
-/sys/devices/bt_wcn3990/rfkill/rfkill0/state                                   u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices(/soc\.0|/soc)?/bluesleep\.(81|89)/rfkill/rfkill0/state                 u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices(/soc\.0|/soc)?/bcm43xx.([0-9])+/rfkill/rfkill[0-9](/.*)?               u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices(/soc\.0|/soc)?/soc\:bcm43xx/rfkill/rfkill0/state                       u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices/bt_wcn3990/rfkill/rfkill0/state                                        u:object_r:sysfs_bluetooth_writable:s0
+/sys/devices/bt_wcn3990/extldo                                                      u:object_r:sysfs_bluetooth_writable:s0
 
 # Storage
 /sys/devices(/soc\.0|/soc)?/(fd80000|0)?\.qcom,rmtfs_sharedmem/uio/uio0/name                        u:object_r:sysfs_rmt_storage:s0
@@ -169,23 +170,24 @@
 /sys/devices(/soc\.0|/soc)?/00-qcom,pm(8941|8950|8994)_rtc/rtc/rtc0/since_epoch                     u:object_r:sysfs_timekeep:s0
 
 # Power management
-/sys/class/power_supply/battery(/.*)?                                                         u:object_r:sysfs_battery_supply:s0
-/sys/class/power_supply/usb(/.*)?                                                             u:object_r:sysfs_usb_supply:s0
+/sys/class/power_supply/battery(/.*)?                                                               u:object_r:sysfs_battery_supply:s0
+/sys/class/power_supply/usb(/.*)?                                                                   u:object_r:sysfs_usb_supply:s0
 
 # Video
-/sys/devices(/soc\.0|/soc)?/fd8c0000\.qcom,msm-cam/video4linux/video0/name                    u:object_r:sysfs_video:s0
-/sys/devices(/soc\.0|/soc)?/fd878000\.qcom,fd/video4linux/video1/name                         u:object_r:sysfs_video:s0
+/sys/devices(/soc\.0|/soc)?/fd8c0000\.qcom,msm-cam/video4linux/video0/name                          u:object_r:sysfs_video:s0
+/sys/devices(/soc\.0|/soc)?/fd878000\.qcom,fd/video4linux/video1/name                               u:object_r:sysfs_video:s0
 
 # WiFi MAC address
-/sys/devices(/soc\.0|/soc)?/fb000000\.qcom,wcnss-wlan/wcnss_mac_addr                          u:object_r:sysfs_addrsetup:s0
-/sys/devices/platform/bcmdhd_wlan/macaddr                                                     u:object_r:sysfs_addrsetup:s0
-/sys/devices/soc/soc\:bcmdhd_wlan/macaddr                                                     u:object_r:sysfs_addrsetup:s0
-/sys/devices(/soc\.0|/soc)?/bcmdhd_wlan.(90|115)/macaddr                                      u:object_r:sysfs_addrsetup:s0
-/sys/devices(/soc\.0|/soc)?/(fb21b000|a21b000)\.qcom,pronto/subsys2/name                      u:object_r:sysfs_pronto:s0
-/sys/module/bcmdhd/parameters/firmware_path                                                   u:object_r:sysfs_wlan_fwpath:s0
+/sys/devices(/soc\.0|/soc)?/fb000000\.qcom,wcnss-wlan/wcnss_mac_addr                                u:object_r:sysfs_addrsetup:s0
+/sys/devices/platform/bcmdhd_wlan/macaddr                                                           u:object_r:sysfs_addrsetup:s0
+/sys/devices/soc/soc\:bcmdhd_wlan/macaddr                                                           u:object_r:sysfs_addrsetup:s0
+/sys/devices(/soc\.0|/soc)?/bcmdhd_wlan.(90|115)/macaddr                                            u:object_r:sysfs_addrsetup:s0
+/sys/devices(/soc\.0|/soc)?/(fb21b000|a21b000)\.qcom,pronto/subsys2/name                            u:object_r:sysfs_pronto:s0
+/sys/module/bcmdhd/parameters/firmware_path                                                         u:object_r:sysfs_wlan_fwpath:s0
+/sys/module/wlan/parameters/fwpath                                                                  u:object_r:sysfs_wlan_fwpath:s0
 
 # Zram
-/sys/devices/virtual/block/zram0/mem_used_total                                          u:object_r:sysfs_zram:s0
+/sys/devices/virtual/block/zram0/mem_used_total                                                     u:object_r:sysfs_zram:s0
 
 ###################################
 # data files
@@ -217,9 +219,9 @@
 ###################################
 # proc files
 #
-/proc/bluetooth/sleep/proto                             u:object_r:sysfs_bluetooth_writable:s0
-/proc/bluetooth/sleep/lpm                               u:object_r:sysfs_bluetooth_writable:s0
-/proc/bluetooth/sleep/btwrite                           u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/proto                                         u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/lpm                                           u:object_r:sysfs_bluetooth_writable:s0
+/proc/bluetooth/sleep/btwrite                                       u:object_r:sysfs_bluetooth_writable:s0
 
 ###################################
 # adsp files


### PR DESCRIPTION
related with HDIL binder

09-18 08:40:40.138   591   591 W bluetooth@1.0-s: type=1400 audit(0.0:393): avc: denied { write } for name=extldo dev=sysfs ino=43895 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>