### PR TITLE
sepolicy: avoid qcom bt denials

### DIFF
--- a/start_hci_filter.te
+++ b/start_hci_filter.te
@@ -9,10 +9,10 @@ allow start_hci_filter proc_sysrq:file rw_file_perms;
 
 get_prop(start_hci_filter, bluetooth_prop)
 
-allow start_hci_filter bluetooth_data_file:dir { w_dir_perms };
-allow start_hci_filter bluetooth_data_file:file { rw_file_perms };
-allow start_hci_filter bt_firmware_file:dir { r_dir_perms };
-allow start_hci_filter bt_firmware_file:file { r_file_perms };
+allow start_hci_filter bluetooth_data_file:dir w_dir_perms;
+allow start_hci_filter bluetooth_data_file:file create_file_perms;
+allow start_hci_filter bt_firmware_file:dir r_dir_perms;
+allow start_hci_filter bt_firmware_file:file r_file_perms;
 allow start_hci_filter hci_attach_dev:chr_file { ioctl open read write };
 allow start_hci_filter init:unix_stream_socket connectto;
 allow start_hci_filter property_socket:sock_file write;


### PR DESCRIPTION
05-21 13:55:24.671  1981  1981 W wcnss_filter: type=1400 audit(0.0:8): avc: denied { create } for name=bt_fw_version.txt scontext=u:r:start_hci_filter:s0 tcontext=u:object_r:bluetooth_data_file:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>