### PR TITLE
sepolicy: avoid bootanim audio denials

### DIFF
--- a/audioserver.te
+++ b/audioserver.te
@@ -6,3 +6,5 @@ allow shell audioserver_exec:file { execute getattr };
 rw_dir_file(audioserver, powerhal_data_file)
 allow audioserver powerhal_data_file:sock_file create_file_perms;
 allow audioserver system_server:unix_stream_socket connectto;
+
+binder_call(audioserver, bootanim) 

--- a/bootanim.te
+++ b/bootanim.te
@@ -1,3 +1,4 @@
 set_prop(bootanim, boot_animation_prop)
 
 allow bootanim rootfs:lnk_file getattr;
+allow bootanim system_data_file:dir r_dir_perms;


### PR DESCRIPTION
05-21 13:53:34.983   972   972 W AudioOut_D: type=1400 audit(0.0:4): avc: denied { call } for scontext=u:r:audioserver:s0 tcontext=u:r:bootanim:s0 tclass=binder permissive=0
05-21 13:53:34.984   980   980 W AudioOut_15: type=1400 audit(0.0:5): avc: denied { call } for scontext=u:r:audioserver:s0 tcontext=u:r:bootanim:s0 tclass=binder permissive=0
05-21 13:53:34.984   984   984 W AudioOut_1D: type=1400 audit(0.0:6): avc: denied { call } for scontext=u:r:audioserver:s0 tcontext=u:r:bootanim:s0 tclass=binder permissive=0
05-21 13:53:35.262  1027  1027 W BootAnimation::: type=1400 audit(0.0:7): avc: denied { read } for name="system" dev="sda15" ino=2457601 scontext=u:r:bootanim:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>