### PR TITLE
sepolicy: avoid qmuxd denials

### DIFF
--- a/hal_gnss_default.te
+++ b/hal_gnss_default.te
@@ -9,7 +9,9 @@ allow hal_gnss_default sysfs_subsys:dir search;
 allow hal_gnss_default netmgrd_socket:dir search;
 allow hal_gnss_default sysfs_subsys:file r_file_perms;
 allow hal_gnss_default sysfs_subsys:dir r_dir_perms;
-allow hal_gnss_default qmuxd_socket:dir { search write };
+allow hal_gnss_default qmuxd_socket:dir { add_name search write };
+allow hal_gnss_default qmuxd_socket:sock_file { create write };
+allow hal_gnss_default qmuxd:unix_stream_socket connectto;
 
 # Most HALs are not allowed to use network sockets. Qcom library
 # libqdi is used across multiple processes which are clients of


### PR DESCRIPTION
09-26 21:19:29.389  1455  1455 W Loc_hal_worker: type=1400 audit(0.0:101): avc: denied { add_name } for name=716D75785F636C69656E745F736F636B657420202031343535 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=dir permissive=0
09-26 21:37:50.519  1125  1125 W Loc_hal_worker: type=1400 audit(0.0:66): avc: denied { create } for name=716D75785F636C69656E745F736F636B657420202031313235 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=sock_file permissive=0
09-26 22:03:41.969  1178  1178 W Loc_hal_worker: type=1400 audit(0.0:61): avc: denied { write } for name="qmux_connect_socket" dev="tmpfs" ino=16903 scontext=u:r:hal_gnss_default:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=sock_file permissive=0
09-26 22:15:30.299  1295  1295 W Loc_hal_worker: type=1400 audit(0.0:47): avc: denied { connectto } for path="/dev/socket/qmux_radio/qmux_connect_socket" scontext=u:r:hal_gnss_default:s0 tcontext=u:r:qmuxd:s0 tclass=unix_stream_socket permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>