### PR TITLE
Camera selinux denials

### DIFF
--- a/mm-qcamerad.te
+++ b/mm-qcamerad.te
@@ -29,3 +29,6 @@ allow mm-qcamerad camera_prop:property_service set;
 allow mm-qcamerad property_socket:sock_file write;
 allow mm-qcamerad init:unix_stream_socket connectto;
 allow mm-qcamerad debugfs:dir read;
+allow mm-qcamerad ion_device:chr_file rw_file_perms;
+
+r_dir_file(mm-qcamerad, sysfs_video)


### PR DESCRIPTION
This solves the camera avc denial selinux problem in Nougat 7.1.1