### PR TITLE
sepolicy: clean system_server

### DIFF
--- a/crash_dump.te
+++ b/crash_dump.te
@@ -1,0 +1,1 @@
+allow crash_dump app_data_file:dir search;

--- a/system_server.te
+++ b/system_server.te
@@ -1,52 +1,22 @@
 allow system_server self:capability sys_module;
 
-# Access to sensors socket
-unix_socket_connect(system_server, sensors, sensors)
-unix_socket_send(system_server, sensors, sensors)
-allow system_server sensors:unix_stream_socket sendto;
-allow system_server sensors_socket:sock_file r_file_perms;
-qmux_socket(system_server);
-
-#Allow access to netmgrd socket
-netmgr_socket(system_server);
-
-#Rules for system server to talk to peripheral manager
-use_per_mgr(system_server);
-
-allow system_server { persist_file system_app_data_file }:dir { open read search };
-allow system_server persist_file:file rw_file_perms;
-allow system_server xlat_prop:file r_file_perms;
-allow system_server unlabeled:file unlink;
-allow system_server storage_stub_file:dir getattr;
-
-# PowerHAL
-rw_dir_file(system_server, powerhal_socket)
-allow system_server powerhal_socket:sock_file create_file_perms;
-
-allow system_server media_rw_data_file:dir r_dir_perms;
-
-allow system_server sensors_persist_file:dir search;
-allow system_server sensors_persist_file:file { open read };
-
-allow system_server self:socket create_socket_perms;
-allowxperm system_server self:socket ioctl msm_sock_ipc_ioctls;
-
-allow system_server audioserver:file w_file_perms;
-allow system_server hal_audio_default:file w_file_perms;
-allow system_server radio:file w_file_perms;
-allow system_server cameraserver:file w_file_perms;
-allow system_server bluetooth:file w_file_perms;
+# timerslack_ns
+allow system_server {
+    audioserver
+    cameraserver
+    hal_audio_default
+    isolated_app
+    platform_app
+    priv_app
+    system_app
+    untrusted_app
+    untrusted_app_25
+}:file write;
 
 # kgsl
 allow system_server debugfs_kgsl:dir search;
 allow system_server debugfs_kgsl:file { open read getattr };
 
-allow system_server platform_app:file w_file_perms;
-allow system_server priv_app:file w_file_perms;
-allow system_server system_app:file w_file_perms;
-allow system_server isolated_app:file w_file_perms;
-
-r_dir_file(system_server, sysfs_addrsetup)
-r_dir_file(system_server, sysfs_pronto)
-r_dir_file(system_server, sysfs_socinfo)
-r_dir_file(system_server, sysfs_subsys)
+# PowerHAL
+rw_dir_file(system_server, powerhal_socket)
+allow system_server powerhal_socket:sock_file create_file_perms;


### PR DESCRIPTION
re-work for oreo and based on https://source.codeaurora.org/quic/la/device/qcom/sepolicy/tree/?h=LA.UM.6.4.r1-04000-8x98.0

Signed-off-by: David Viteri <davidteri91@gmail.com>