### PR TITLE
sepolicy: avoid mediaextractor denials

### DIFF
--- a/mediaextractor.te
+++ b/mediaextractor.te
@@ -1,0 +1,1 @@
+allow mediaextractor sdcardfs:file read;


### PR DESCRIPTION
10-20 22:08:13.676  9062  9062 W generic : type=1400 audit(0.0:187): avc: denied { read } for path=/storage/emulated/0/DCIM/Camera/VID_20171020_220807.mp4 dev=sdcardfs ino=791570 scontext=u:r:mediaextractor:s0 tcontext=u:object_r:sdcardfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>