### PR TITLE
sepolicy: avoid more mediaextractor denials

### DIFF
--- a/mediaextractor.te
+++ b/mediaextractor.te
@@ -1,1 +1,1 @@
-allow mediaextractor sdcardfs:file read;
+allow mediaextractor sdcardfs:file { getattr read };


### PR DESCRIPTION
10-20 22:55:59.119  4603  4603 W Binder:616_5: type=1400 audit(0.0:33): avc: denied { getattr } for path=2F73746F726167652F656D756C617465642F302F5370696465726D616E20322E617669 dev="sdcardfs" ino=791573 scontext=u:r:mediaextractor:s0 tcontext=u:object_r:sdcardfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>