### PR TITLE
[DNM] part 2 of rfkill permission fix.

### DIFF
--- a/device.te
+++ b/device.te
@@ -65,3 +65,6 @@ type persist_block_device, dev_type;
 
 #Define Bluetooth device
 type bt_device, dev_type;
+
+#Define Wifi rfkill device
+type rfkill_device, dev_type;

--- a/file_contexts
+++ b/file_contexts
@@ -39,6 +39,7 @@
 /dev/pn54x                                      u:object_r:nfc_device:s0
 /dev/subsys_modem                               u:object_r:subsys_modem_device:s0
 /dev/tfa98xx                                    u:object_r:audio_device:s0
+/dev/rfkill					u:object_r:rfkill_device:s0
 
 ###################################
 # Dev socket nodes

--- a/hal_wifi_default.te
+++ b/hal_wifi_default.te
@@ -1,1 +1,2 @@
 allow hal_wifi_default sysfs_wlan_fwpath:file w_file_perms;
+allow hal_wifi_supplicant_default rfkill_device:chr_file { open read };

--- a/hostapd.te
+++ b/hostapd.te
@@ -1,0 +1,1 @@
+allow hostapd rfkill_device:chr_file { read open };


### PR DESCRIPTION
Generated with
adb logcat -b all -d | audit2allow -p policy