### PR TITLE
sepolicy: avoid system_server denials

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -8,6 +8,7 @@ allow system_server {
     isolated_app
     platform_app
     priv_app
+    radio
     system_app
     untrusted_app
     untrusted_app_25


### PR DESCRIPTION
10-24 01:39:47.296  2035  2035 W Binder:905_E: type=1400 audit(0.0:63): avc: denied { write } for name=timerslack_ns dev=proc ino=19566 scontext=u:r:system_server:s0 tcontext=u:r:radio:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>