### PR TITLE
sepolicy: add ramdump cleaner rules

### DIFF
--- a/device.te
+++ b/device.te
@@ -65,3 +65,6 @@ type persist_block_device, dev_type;
 
 #Define Bluetooth device
 type bt_device, dev_type;
+
+# ramdump partition block device
+type rdimage_block_device, dev_type;

--- a/file_contexts
+++ b/file_contexts
@@ -62,6 +62,7 @@
 /system/vendor/bin/macaddrsetup       u:object_r:addrsetup_exec:s0
 /system/vendor/bin/thermanager        u:object_r:thermanager_exec:s0
 /system/vendor/bin/timekeep           u:object_r:timekeep_exec:s0
+/(vendor|system/vendor)/bin/rdclean.sh          u:object_r:rdclean_exec:s0
 
 ###################################
 # ODM files

--- a/rdclean.te
+++ b/rdclean.te
@@ -1,0 +1,11 @@
+type rdclean_exec, exec_type, file_type;
+
+userdebug_or_eng(`
+  type rdclean, domain;
+
+  init_daemon_domain(rdclean);
+
+  # make sure rdimage_block_device is defined in platform's contexts
+  allow rdclean rdimage_block_device:blk_file rw_file_perms;
+  allow rdclean { shell_exec toolbox_exec }:file rx_file_perms;
+')


### PR DESCRIPTION
Add ramdump partition block device type and set of rules for the
ramdump cleaner script. Each supported platform provides specific
block device label.

Signed-off-by: Oleksiy Avramchenko <oleksiy.avramchenko@sony.com>