### PR TITLE
sepolicy: avoid powerHAL denials

### DIFF
--- a/audioserver.te
+++ b/audioserver.te
@@ -3,8 +3,10 @@ r_dir_file(audioserver, sysfs)
 allow audioserver rootfs:lnk_file getattr;
 allow shell audioserver_exec:file { execute getattr };
 
+# PowerHAL
 rw_dir_file(audioserver, powerhal_data_file)
 allow audioserver powerhal_data_file:sock_file create_file_perms;
 allow audioserver system_server:unix_stream_socket connectto;
+allow audioserver socket_device:sock_file write;
 
 binder_call(audioserver, bootanim) 

--- a/cameraserver.te
+++ b/cameraserver.te
@@ -15,5 +15,6 @@ allow cameraserver property_socket:sock_file write;
 allow cameraserver powerhal_data_file:dir search;
 allow cameraserver powerhal_data_file:sock_file write;
 allow cameraserver system_server:unix_stream_socket connectto;
+allow cameraserver socket_device:sock_file write;
 
 allow cameraserver sysfs:file { open read };

--- a/mediacodec.te
+++ b/mediacodec.te
@@ -1,8 +1,10 @@
 allow mediacodec rootfs:lnk_file getattr;
 
+# PowerHAL
 rw_dir_file(mediacodec, powerhal_data_file)
 allow mediacodec powerhal_data_file:sock_file create_file_perms;
 allow mediacodec system_server:unix_stream_socket connectto;
+allow mediacodec socket_device:sock_file write;
 
 #allow mediacodec to access adsprpcd
 r_dir_file(mediacodec, adsprpcd_file);

--- a/system_server.te
+++ b/system_server.te
@@ -7,10 +7,10 @@ allow system_server sensors:unix_stream_socket sendto;
 allow system_server sensors_socket:sock_file r_file_perms;
 qmux_socket(system_server);
 
-#Allow access to netmgrd socket
+# Allow access to netmgrd socket
 netmgr_socket(system_server);
 
-#Rules for system server to talk to peripheral manager
+# Rules for system server to talk to peripheral manager
 use_per_mgr(system_server);
 
 allow system_server { persist_file system_app_data_file }:dir { open read search };
@@ -19,8 +19,11 @@ allow system_server xlat_prop:file { getattr open read };
 allow system_server unlabeled:file unlink;
 allow system_server storage_stub_file:dir getattr;
 
+# PowerHAL
 rw_dir_file(system_server, powerhal_data_file)
 allow system_server powerhal_data_file:sock_file create_file_perms;
+allow system_server socket_device:dir { add_name write };
+allow system_server socket_device:sock_file { create setattr };
 
 allow system_server media_rw_data_file:dir r_dir_perms;
 


### PR DESCRIPTION
11-02 20:35:17.192  1315  1315 W PhotonicModulat: type=1400 audit(0.0:7): avc: denied { write } for name=powerhal dev=tmpfs ino=10607 scontext=u:r:system_server:s0 tcontext=u:object_r:socket_device:s0 tclass=dir permissive=0
11-02 21:49:28.456   994   994 W system_server: type=1400 audit(0.0:4): avc: denied { add_name } for name="rqbsvr" scontext=u:r:system_server:s0 tcontext=u:object_r:socket_device:s0 tclass=dir permissive=0
11-02 21:56:28.524   984   984 W system_server: type=1400 audit(0.0:4): avc: denied { create } for name="rqbsvr" scontext=u:r:system_server:s0 tcontext=u:object_r:socket_device:s0 tclass=sock_file permissive=0
11-02 22:07:36.245   949   949 W system_server: type=1400 audit(0.0:4): avc: denied { setattr } for name="rqbsvr" dev="tmpfs" ino=19299 scontext=u:r:system_server:s0 tcontext=u:object_r:socket_device:s0 tclass=sock_file permissive=0
11-02 22:12:48.159   623   623 W mediacodec: type=1400 audit(0.0:4): avc: denied { write } for name="rqbsvr" dev="tmpfs" ino=2726 scontext=u:r:mediacodec:s0 tcontext=u:object_r:socket_device:s0 tclass=sock_file permissive=0
11-02 22:19:11.227  2649  2649 W AudioIn_26: type=1400 audit(0.0:5): avc: denied { write } for name="rqbsvr" dev="tmpfs" ino=764 scontext=u:r:audioserver:s0 tcontext=u:object_r:socket_device:s0 tclass=sock_file permissive=0
11-02 22:19:15.954   940   940 W Binder:618_1: type=1400 audit(0.0:6): avc: denied { write } for name="rqbsvr" dev="tmpfs" ino=764 scontext=u:r:cameraserver:s0 tcontext=u:object_r:socket_device:s0 tclass=sock_file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>