### PR TITLE
sepolicy: avoid bt denials

### DIFF
--- a/start_hci_filter.te
+++ b/start_hci_filter.te
@@ -4,6 +4,7 @@ type start_hci_filter_exec, exec_type, file_type;
 init_daemon_domain(start_hci_filter);
 
 allow start_hci_filter self:capability { setuid setgid dac_override };
+allow start_hci_filter self:capability2 block_suspend;
 
 allow start_hci_filter proc_sysrq:file rw_file_perms;
 


### PR DESCRIPTION
11-02 20:53:01.169  1514  1514 W wcnss_filter: type=1400 audit(0.0:70): avc: denied { block_suspend } for capability=36 scontext=u:r:start_hci_filter:s0 tcontext=u:r:start_hci_filter:s0 tclass=capability2 permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>