### PR TITLE
sepolicy: avoid rdclean denials

### DIFF
--- a/rdclean.te
+++ b/rdclean.te
@@ -7,5 +7,6 @@ userdebug_or_eng(`
 
   # make sure rdimage_block_device is defined in platform's contexts
   allow rdclean rdimage_block_device:blk_file rw_file_perms;
+  allow rdclean block_device:dir search;
   allow rdclean { shell_exec toolbox_exec }:file rx_file_perms;
 ')


### PR DESCRIPTION
02-26 01:09:06.789   637   637 W dd      : type=1400 audit(0.0:15): avc: denied { search } for name=block dev=tmpfs ino=11424 scontext=u:r:rdclean:s0 tcontext=u:object_r:block_device:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>