### PR TITLE
sepolicy: avoid sd denials

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -9,6 +9,7 @@ allow system_server {
     platform_app
     priv_app
     radio
+    shell
     system_app
     untrusted_app
     untrusted_app_25


### PR DESCRIPTION
11-07 22:15:31.368  5764  5764 W Binder:1011_12: type=1400 audit(0.0:99): avc: denied { write } for name=timerslack_ns dev=proc ino=68542 scontext=u:r:system_server:s0 tcontext=u:r:shell:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>