### PR TITLE
Fixes for creating MAC address files on Oreo

### DIFF
--- a/addrsetup.te
+++ b/addrsetup.te
@@ -12,6 +12,10 @@ allow addrsetup bluetooth_data_file:file create_file_perms;
 allow addrsetup rootfs:lnk_file getattr;
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
+# Permit creation of wlan_mac.bin
+allow addrsetup wifi_data_file:dir rw_dir_perms;
+allow addrsetup wifi_data_file:file create_file_perms;
+
 unix_socket_connect(addrsetup, tad, tad)
 
 allow addrsetup random_device:file read;

--- a/hal_bluetooth_default.te
+++ b/hal_bluetooth_default.te
@@ -4,3 +4,6 @@ allow hal_bluetooth_default start_hci_filter:unix_stream_socket connectto;
 allow hal_bluetooth_default bt_device:chr_file rw_file_perms;
 allow hal_bluetooth_default oemfs:dir search;
 allow hal_bluetooth_default serial_device:chr_file rw_file_perms;
+
+# Permit reading of bluetooth_bdaddr
+allow hal_bluetooth_default bluetooth_data_file:file r_file_perms;


### PR DESCRIPTION
This adds policy to allow the macaddrsetup service to write the WLAN MAC
address to a file, as well allowing the bluetooth service to read the BT
MAC file written by macaddrsetup.