### PR TITLE
sepolicy: avoid denials for exposed SD

### DIFF
--- a/blkid.te
+++ b/blkid.te
@@ -1,0 +1,1 @@
+allow blkid proc:file { getattr open read };

--- a/fsck.te
+++ b/fsck.te
@@ -1,3 +1,4 @@
 allow fsck random_device:file getattr;
 allow fsck block_device:blk_file { getattr ioctl };
 allow fsck persist_block_device:blk_file { ioctl rw_file_perms };
+allow fsck media_rw_data_file:dir getattr;

--- a/kernel.te
+++ b/kernel.te
@@ -3,9 +3,8 @@ allow kernel device:blk_file rw_file_perms;
 allow kernel tmpfs:file create_file_perms;
 allow kernel tmpfs:dir create_dir_perms;
 allow kernel block_device:blk_file rw_file_perms;
-allow kernel kernel:capability mknod;
+allow kernel self:capability mknod;
 allow kernel self:socket create_socket_perms_no_ioctl;
-allow kernel self:capability { mknod };
 
 # Access firmware_file
 r_dir_file(kernel, firmware_file)

--- a/netd.te
+++ b/netd.te
@@ -1,5 +1,2 @@
-allow netd netd:capability sys_module;
+allow netd self:capability sys_module;
 allow netd kernel:system module_request;
-allow netd untrusted_app:unix_stream_socket { read write };
-
-binder_use(netd);

--- a/nfc.te
+++ b/nfc.te
@@ -2,4 +2,3 @@ allow nfc media_rw_data_file:dir rw_dir_perms;
 allow nfc media_rw_data_file:file rename;
 
 allow nfc nfc_data_file:file rw_file_perms;
-allow nfc nfc_data_file:dir rw_dir_perms;

--- a/system_app.te
+++ b/system_app.te
@@ -14,7 +14,6 @@ allow system_app {
 
 allow system_app timekeep_data_file:dir { create_dir_perms search };
 allow system_app timekeep_data_file:file create_file_perms;
-allow system_app media_rw_data_file:dir r_dir_perms;
 allow system_app fuse_device:filesystem getattr;
 allow system_app fingerprintd:binder call;
 allow system_app debugfs_kgsl:dir search;

--- a/vold.te
+++ b/vold.te
@@ -5,3 +5,4 @@ allow vold logd:lnk_file { read getattr };
 allow vold tee_prop:file r_file_perms;
 allow vold kernel:system module_request;
 allow vold oemfs:dir search;
+allow vold apk_data_file:dir getattr;

--- a/vold.te
+++ b/vold.te
@@ -1,11 +1,7 @@
 allow vold random_device:file { getattr open read };
-allow vold storage_stub_file:dir rw_dir_perms;
 allow vold fuse_device:dir { open read search write };
 allow vold logd:dir { open read getattr };
 allow vold logd:lnk_file { read getattr };
-
-allow vold tee_prop:file { r_file_perms };
+allow vold tee_prop:file r_file_perms;
 allow vold kernel:system module_request;
-
-allow vold block_device:blk_file { getattr ioctl };
 allow vold oemfs:dir search;


### PR DESCRIPTION
also remove vold duplicate perms already defined at https://android.googlesource.com/platform/system/sepolicy/+/android-8.0.0_r30/public/vold.te

Signed-off-by: David Viteri <davidteri91@gmail.com>