### PR TITLE
sepolicy: avoid gps denials

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -22,3 +22,9 @@ allow system_server debugfs_kgsl:file { open read getattr };
 # PowerHAL
 rw_dir_file(system_server, powerhal_socket)
 allow system_server powerhal_socket:sock_file create_file_perms;
+
+allow system_server netmgrd_socket:dir search;
+allow system_server netmgrd_socket:sock_file write;
+allow system_server netmgrd:unix_stream_socket connectto;
+allow system_server self:socket ioctl;
+allowxperm system_server self:socket ioctl msm_sock_ipc_ioctls;


### PR DESCRIPTION
11-19 23:20:43.044  1422  1422 W Loc_hal_worker: type=1400 audit(0.0:22601021): avc: denied { ioctl } for path=socket:[15838] dev=sockfs ino=15838 ioctlcmd=c302 scontext=u:r:system_server:s0 tcontext=u:r:system_server:s0 tclass=socket permissive=0
11-19 23:47:53.859  1465  1465 W Loc_hal_worker: type=1400 audit(0.0:128): avc: denied { search } for name="netmgr" dev="tmpfs" ino=16586 scontext=u:r:system_server:s0 tcontext=u:object_r:netmgrd_socket:s0 tclass=dir permissive=0
11-19 23:58:21.889  1458  1458 W Loc_hal_worker: type=1400 audit(0.0:112): avc: denied { write } for name="netmgr_connect_socket" dev="tmpfs" ino=15637 scontext=u:r:system_server:s0 tcontext=u:object_r:netmgrd_socket:s0 tclass=sock_file permissive=0
11-20 00:03:19.649  1448  1448 W Loc_hal_worker: type=1400 audit(0.0:107): avc: denied { connectto } for path="/dev/socket/netmgr/netmgr_connect_socket" scontext=u:r:system_server:s0 tcontext=u:r:netmgrd:s0 tclass=unix_stream_socket permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>