### PR TITLE
sepolicy: avoid init denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -4,8 +4,8 @@
 /dev/kgsl-3d0                                   u:object_r:gpu_device:s0
 /dev/rtc0                                       u:object_r:rtc_device:s0
 /dev/smd.*                                      u:object_r:smd_device:s0
-# TODO: does ttyMSM0 need to be more specific
-/dev/ttyMSM0                                    u:object_r:tty_device:s0
+/dev/ttyHS0                                     u:object_r:serial_device:s0
+/dev/ttyMSM0                                    u:object_r:console_device:s0
 /dev/ipa                                        u:object_r:ipa_dev:s0
 /dev/wwan_ioctl                                 u:object_r:ipa_dev:s0
 /dev/ipaNatTable                                u:object_r:ipa_dev:s0
@@ -35,7 +35,6 @@
 /dev/socket/qmux_radio(/.*)?                    u:object_r:qmuxd_socket:s0
 /dev/socket/msm_irqbalance                      u:object_r:irqbalance_socket:s0
 /dev/socket/netmgr(/.*)?                        u:object_r:netmgrd_socket:s0
-/dev/ttyHS0                                     u:object_r:hci_attach_dev:s0
 /dev/socket/powerhal(/.*)?                      u:object_r:powerhal_socket:s0
 /dev/socket/tad                                 u:object_r:tad_socket:s0
 

--- a/hal_bluetooth_default.te
+++ b/hal_bluetooth_default.te
@@ -6,3 +6,5 @@ set_prop(hal_bluetooth_default, bluetooth_prop)
 rw_dir_file(hal_bluetooth_default, sysfs_bluetooth)
 
 allow hal_bluetooth_default bluetooth_data_file:file r_file_perms;
+allow hal_bluetooth_default sysfs:file w_file_perms;
+allow hal_bluetooth_default wcnss_filter:unix_stream_socket connectto;

--- a/hal_gatekeeper_default.te
+++ b/hal_gatekeeper_default.te
@@ -1,1 +1,2 @@
 set_prop(hal_gatekeeper_default, keymaster_prop)
+get_prop(hal_gatekeeper_default, tee_listener_prop)

--- a/hal_keymaster_default.te
+++ b/hal_keymaster_default.te
@@ -1,1 +1,3 @@
 allow hal_keymaster_default keymaster_prop:file r_file_perms;
+
+get_prop(hal_keymaster_default, tee_listener_prop)

--- a/init.te
+++ b/init.te
@@ -3,12 +3,13 @@ allow init tmpfs:lnk_file create;
 allow init configfs:lnk_file create;
 
 allow init persist_file:dir mounton;
+allow init configfs:file w_file_perms;
 
 dontaudit init kernel:system module_request;
 
 allow init proc_cmdline:file r_file_perms;
 
-#Allow triggering IPA FWs loading
+# Allow triggering IPA FWs loading
 allow init ipa_dev:chr_file write;
 
 # init_power.te

--- a/per_proxy.te
+++ b/per_proxy.te
@@ -5,6 +5,7 @@ type per_proxy_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(per_proxy)
 
 allow per_proxy per_mgr_service:service_manager find;
+r_dir_file(per_proxy, sysfs_msm_subsys)
 
 binder_use(per_proxy)
 binder_call(per_proxy, per_mgr)

--- a/wcnss_filter.te
+++ b/wcnss_filter.te
@@ -2,3 +2,15 @@ type wcnss_filter, domain;
 type wcnss_filter_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(wcnss_filter)
+
+set_prop(wcnss_filter, wc_prop)
+set_prop(wcnss_filter, bluetooth_prop)
+
+allow wcnss_filter bluetooth_data_file:file rw_file_perms;
+allow wcnss_filter bt_firmware_file:file { getattr read open };
+allow wcnss_filter self:capability2 block_suspend;
+allow wcnss_filter serial_device:chr_file rw_file_perms;
+allow wcnss_filter init:unix_stream_socket connectto;
+
+# allow wakelock
+wakelock_use(wcnss_filter)

--- a/wcnss_service.te
+++ b/wcnss_service.te
@@ -4,6 +4,18 @@ type wcnss_service_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(wcnss_service)
 net_domain(wcnss_service)
 
+r_dir_file(wcnss_service, sysfs_msm_subsys)
+allow wcnss_service per_mgr_service:service_manager find;
+
+allow wcnss_service self:socket create_socket_perms;
+allowxperm wcnss_service self:socket ioctl msm_sock_ipc_ioctls;
+allow wcnss_service self:netlink_generic_socket create_socket_perms_no_ioctl;
+
+allow wcnss_service self:capability net_admin;
+
+allow wcnss_service sysfs_soc:dir r_dir_perms;
+allow wcnss_service sysfs_soc:file r_file_perms;
+
 binder_use(wcnss_service)
 vndbinder_use(wcnss_service)
 binder_call(wcnss_service, per_mgr)


### PR DESCRIPTION
03-20 01:45:11.732     1     1 I init    : type=1400 audit(0.0:14): avc: denied { write } for name=idVendor dev=configfs ino=14872 scontext=u:r:init:s0 tcontext=u:object_r:configfs:s0 tclass=file permissive=1
03-20 01:45:11.858     1     1 W init    : type=1400 audit(0.0:19): avc: granted { read open } for path=/dev/ttyMSM0 dev=tmpfs ino=14520 scontext=u:r:init:s0 tcontext=u:object_r:tty_device:s0 tclass=chr_file

Signed-off-by: David Viteri <davidteri91@gmail.com>