### PR TITLE
sepolicy: avoid bt denials

### DIFF
--- a/wcnss_filter.te
+++ b/wcnss_filter.te
@@ -6,7 +6,8 @@ init_daemon_domain(wcnss_filter)
 set_prop(wcnss_filter, wc_prop)
 set_prop(wcnss_filter, bluetooth_prop)
 
-allow wcnss_filter bluetooth_data_file:file rw_file_perms;
+allow wcnss_filter bluetooth_data_file:file create_file_perms;
+allow wcnss_filter bluetooth_data_file:dir rw_dir_perms;
 allow wcnss_filter hci_attach_dev:chr_file rw_file_perms;
 
 #allow wakelock


### PR DESCRIPTION
03-25 13:50:02.749  1590  1590 I wcnss_filter: type=1400 audit(0.0:41): avc: denied { write } for name=bluedroid dev=sda66 ino=32770 scontext=u:r:wcnss_filter:s0 tcontext=u:object_r:bluetooth_data_file:s0 tclass=dir permissive=1
03-25 13:50:02.749  1590  1590 I wcnss_filter: type=1400 audit(0.0:42): avc: denied { add_name } for name=bt_fw_version.txt scontext=u:r:wcnss_filter:s0 tcontext=u:object_r:bluetooth_data_file:s0 tclass=dir permissive=1
03-25 13:50:02.749  1590  1590 I wcnss_filter: type=1400 audit(0.0:43): avc: denied { create } for name=bt_fw_version.txt scontext=u:r:wcnss_filter:s0 tcontext=u:object_r:bluetooth_data_file:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>