### PR TITLE
sony: sepolicy: Do not audit cameraserver timerslack_ns

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -13,6 +13,7 @@ dontaudit system_server audioserver:file write;
 dontaudit system_server untrusted_app:file write;
 dontaudit system_server hal_audio_default:file write;
 dontaudit system_server appdomain:file write;
+dontaudit system_server cameraserver:file write;
 
 allow system_server proc_cmdline:file r_file_perms;
 allow system_server netmgrd_socket:dir r_dir_perms;


### PR DESCRIPTION
avc: denied { write } for pid=3982 comm="Binder:867_E" name="timerslack_ns"
dev="proc" ino=36459 scontext=u:r:system_server:s0
tcontext=u:r:cameraserver:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I05a62de452b1ef93eaeaa099bb8c8f4678814c32