### PR TITLE
sepolicy: avoid cam denials

### DIFF
--- a/hal_camera_default.te
+++ b/hal_camera_default.te
@@ -16,3 +16,6 @@ allow hal_camera_default gpu_device:chr_file rw_file_perms;
 
 allow hal_camera_default hal_power_default:unix_stream_socket connectto;
 allow hal_camera_default powerhal_socket:sock_file write;
+
+allow hal_camera_default sysfs_msm_subsys:dir search;
+allow hal_camera_default sysfs_msm_subsys:file r_file_perms;


### PR DESCRIPTION
04-04 01:43:28.547   630   630 I android.hardwar: type=1400 audit(0.0:28): avc: denied { search } for name=c900000.qcom,mdss_rotator dev=sysfs ino=23542 scontext=u:r:hal_camera_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=dir permissive=1
04-04 01:43:28.547   630   630 I android.hardwar: type=1400 audit(0.0:29): avc: denied { read } for name=name dev=sysfs ino=39057 scontext=u:r:hal_camera_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1
04-04 01:43:28.547   630   630 I android.hardwar: type=1400 audit(0.0:30): avc: denied { open } for path=/sys/devices/soc/c900000.qcom,mdss_rotator/video4linux/video1/name dev=sysfs ino=39057 scontext=u:r:hal_camera_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>