### PR TITLE
sepolicy: avoid Gcam denials

### DIFF
--- a/hal_camera_default.te
+++ b/hal_camera_default.te
@@ -16,6 +16,7 @@ allow hal_camera_default gpu_device:chr_file rw_file_perms;
 
 allow hal_camera_default hal_power_default:unix_stream_socket connectto;
 allow hal_camera_default powerhal_socket:sock_file write;
+allow hal_camera_default powerhal_socket:dir search;
 
 allow hal_camera_default sysfs_msm_subsys:dir search;
 allow hal_camera_default sysfs_msm_subsys:file r_file_perms;

--- a/untrusted_app.te
+++ b/untrusted_app.te
@@ -1,0 +1,1 @@
+allow untrusted_app camera_prop:file r_file_perms;


### PR DESCRIPTION
12-11 11:21:33.905  8284  8284 I HwBinder:627_3: type=1400 audit(0.0:324): avc: denied { search } for name=powerhal dev=tmpfs ino=13663 scontext=u:r:hal_camera_default:s0 tcontext=u:object_r:powerhal_socket:s0 tclass=dir permissive=1
12-11 11:21:51.541 15721 15721 I id.GoogleCamera: type=1400 audit(0.0:326): avc: denied { open } for path=/dev/__properties__/u:object_r:camera_prop:s0 dev=tmpfs ino=14351 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:camera_prop:s0 tclass=file permissive=1
12-11 11:21:51.541 15721 15721 I id.GoogleCamera: type=1400 audit(0.0:327): avc: denied { getattr } for path=/dev/__properties__/u:object_r:camera_prop:s0 dev=tmpfs ino=14351 scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:camera_prop:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>