### PR TITLE
Initial odmcheck (2/4)

### DIFF
--- a/file.te
+++ b/file.te
@@ -15,6 +15,7 @@ type sysfs_bluetooth, sysfs_type, fs_type;
 type sysfs_pcc_profile, sysfs_type, fs_type;
 type sysfs_rtc, sysfs_type, fs_type;
 type sysfs_timekeep, sysfs_type, fs_type;
+type sysfs_odmcheck, sysfs_type, fs_type;
 
 type debugfs_clk, debugfs_type, fs_type;
 type debugfs_ion, debugfs_type, fs_type;
@@ -71,3 +72,5 @@ type sysfs_irq, fs_type;
 type irqbalance_socket, file_type;
 
 type proc_cmdline, fs_type;
+
+type proc_version, fs_type;

--- a/file_contexts
+++ b/file_contexts
@@ -44,6 +44,7 @@
 /system/vendor/bin/macaddrsetup       u:object_r:addrsetup_exec:s0
 /system/vendor/bin/thermanager        u:object_r:thermanager_exec:s0
 /system/vendor/bin/timekeep           u:object_r:timekeep_exec:s0
+/system/vendor/bin/odmcheck           u:object_r:odmcheck_exec:s0
 
 # files in /vendor
 /vendor/firmware(/.*)?          u:object_r:vendor_firmware_file:s0

--- a/genfs_contexts
+++ b/genfs_contexts
@@ -1,5 +1,6 @@
 genfscon proc /irq                                    u:object_r:proc_irq:s0
 genfscon proc /cmdline                                u:object_r:proc_cmdline:s0
+genfscon proc /version                                u:object_r:proc_version:s0
 
 genfscon sysfs /devices/soc/soc:qcom,cpubw            u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/soc/soc:qcom,mincpubw         u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
Odmcheck will block init until exited. If a mismatch between odm partition and the build props is detected a warning screen will be shown. Currently this warning screen just has a simple placeholder UI with the version information shown on a blue background. The warning screen will be shown for 10 seconds, then the boot will resume regardless. Once everything is in place and works fine, after changing a build flag, odmcheck will instead shutdown the device after the 10 seconds.