### PR TITLE
[master] sony: sepolicy: Address init denials

### DIFF
--- a/init.te
+++ b/init.te
@@ -1,5 +1,6 @@
 # symlink /sdcard to backing block
 allow init tmpfs:lnk_file create;
+allow init configfs:file rw_file_perms;
 allow init configfs:lnk_file create;
 
 allow init persist_file:dir mounton;


### PR DESCRIPTION
avc: denied { write } for pid=1 comm="init" name="configuration"
dev="configfs" ino=10706 scontext=u:r:init:s0 tcontext=u:object_r:configfs:s0
tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Id81ab90db563296b7ad254710c501f21779bd1eb