### PR TITLE
[master] sony: sepolicy: Add more configfs permissions for init

### DIFF
--- a/init.te
+++ b/init.te
@@ -1,8 +1,7 @@
 # symlink /sdcard to backing block
 allow init tmpfs:lnk_file create;
 allow init configfs:file rw_file_perms;
-allow init configfs:lnk_file create;
-allow init configfs:file rw_file_perms;
+allow init configfs:lnk_file { create unlink };
 
 allow init persist_file:dir mounton;
 


### PR DESCRIPTION
avc: denied { unlink } for pid=1 comm="init" name="f1" dev="configfs"
ino=46216 scontext=u:r:init:s0 tcontext=u:object_r:configfs:s0
tclass=lnk_file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I078d7b305d691df0e1ded5b741c6a72b62e78d64