### PR TITLE
Trivial: update comment to avoid syntax warning

### DIFF
--- a/rdclean.te
+++ b/rdclean.te
@@ -5,7 +5,7 @@ userdebug_or_eng(`
 
   init_daemon_domain(rdclean);
 
-  # make sure rdimage_block_device is defined in platform's contexts
+  # make sure rdimage_block_device is defined in platform context
   allow rdclean rdimage_block_device:blk_file rw_file_perms;
   allow rdclean { shell_exec toolbox_exec }:file rx_file_perms;
 ')


### PR DESCRIPTION
because of the apostrophe in the comment, the following warnings were
emitted during a build:

```
device/sony/sepolicy/rdclean.te:3:WARNING 'unrecognized character' at token ''' on line 22982:
'
#line 3
device/sony/sepolicy/rdclean.te:3:WARNING 'unrecognized character' at token ''' on line 22982:
'
#line 3
out/host/linux-x86/bin/checkpolicy:  loading policy configuration from out/target/product/maple/obj/ETC/sepolicy_intermediates/policy.conf
out/host/linux-x86/bin/checkpolicy:  policy configuration loaded
out/host/linux-x86/bin/checkpolicy:  writing binary representation (version 30) to out/target/product/maple/obj/ETC/sepolicy_intermediates/sepolicy.tmp
```