### PR TITLE
[master] sony: sepolicy: Allow untrusted apps reading thermal sysfs

### DIFF
--- a/untrusted_app.te
+++ b/untrusted_app.te
@@ -1,0 +1,1 @@
+r_dir_file(untrusted_app, sysfs_thermal)


### PR DESCRIPTION
It is useful for apps that plots thermal reports.

avc: denied { search } for pid=10374 comm="inalwire.aida64"
name="thermal" dev="sysfs" ino=37998
scontext=u:r:untrusted_app:s0:c512,c768
tcontext=u:object_r:sysfs_thermal:s0 tclass=dir permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ic2b7a3060066eced5779c3b4ef4ff012cb4653bc