### PR TITLE
[master] sony: sepolicy: Address dsp denials

### DIFF
--- a/fsck.te
+++ b/fsck.te
@@ -1,1 +1,2 @@
+allow fsck adsprpcd_block_device:blk_file rw_file_perms;
 allow fsck persist_block_device:blk_file rw_file_perms;

--- a/init.te
+++ b/init.te
@@ -3,7 +3,7 @@ allow init tmpfs:lnk_file create;
 allow init configfs:file rw_file_perms;
 allow init configfs:lnk_file { create unlink };
 
-allow init persist_file:dir mounton;
+allow init { persist_file qdsp_file }:dir mounton;
 
 dontaudit init kernel:system module_request;
 


### PR DESCRIPTION
avc:  denied  { mounton } for  pid=461 comm="init" path="/dsp"
dev="rootfs" ino=8282 scontext=u:r:init:s0
tcontext=u:object_r:qdsp_file:s0 tclass=dir permissive=0

avc:  denied  { read } for  pid=480 comm="e2fsck" name="mmcblk0p32"
dev="tmpfs" ino=8823 scontext=u:r:fsck:s0
tcontext=u:object_r:adsprpcd_block_device:s0 tclass=blk_file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Iae6778eb228dd8b3d88181ab7c63ff30b3fa3d63