### PR TITLE
sepolicy: avoid qcom bt denials

### DIFF
--- a/genfs_contexts
+++ b/genfs_contexts
@@ -10,7 +10,8 @@ genfscon sysfs /devices/mdss_dsi_panel/pcc_profile    u:object_r:sysfs_pcc_profi
 genfscon sysfs /devices/virtual/smdpkt                u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /class/uio                                               u:object_r:sysfs_uio:s0
-genfscon sysfs /devices/soc/soc:bt_wcn3990                              u:object_r:sysfs_bluetooth_writable:s0
+genfscon sysfs /devices/bt_wcn3990/rfkill/rfkill0/state                 u:object_r:sysfs_bluetooth_writable:s0
+genfscon sysfs /devices/bt_wcn3990/extldo                               u:object_r:sysfs_bluetooth_writable:s0
 genfscon sysfs /devices/soc/soc:qcom,gpubw                              u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/soc/soc:qcom,kgsl-hyp                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/soc/soc:qcom,ipa_fws@1e08000                    u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
12-10 23:44:24.287   643   643 I bluetooth@1.0-s: type=1400 audit(0.0:36): avc: denied { write } for name=state dev=sysfs ino=40854 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
12-11 00:01:47.200  1553  1553 I HwBinder:618_1: type=1400 audit(0.0:36): avc: denied { write } for name="extldo" dev="sysfs" ino=40843 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>