### PR TITLE
sepolicy: Allow nfc service access

### DIFF
--- a/platform_app.te
+++ b/platform_app.te
@@ -1,0 +1,1 @@
+allow platform_app nfc_service:service_manager find;


### PR DESCRIPTION
11-23 21:38:31.704   553   553 E SELinux : avc:  denied  { find } for service=nfc pid=1302 uid=10029 scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:nfc_service:s0 tclass=service_manager

Signed-off-by: David Viteri <davidteri91@gmail.com>