### PR TITLE
[master] sepolicy: avoid location denials

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -28,4 +28,5 @@ unix_socket_connect(system_server, qmuxd, qmuxd)
 
 # xtra
 allow system_server location_data_file:sock_file write;
+allow system_server location_data_file:dir search;
 allow system_server location:unix_stream_socket connectto;


### PR DESCRIPTION
01-10 02:48:10.551  1032  1032 W android.bg: type=1400 audit(0.0:41): avc: denied { search } for name=location dev=sda66 ino=557059 scontext=u:r:system_server:s0 tcontext=u:object_r:location_data_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>