### PR TITLE
sepolicy: allow settings read kernel version

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -5,3 +5,6 @@ rw_dir_file(system_app, sysfs_pcc_profile)
 allow system_app timekeep_vendor_data_file:dir create_dir_perms;
 allow system_app timekeep_vendor_data_file:file create_file_perms;
 set_prop(system_app, timekeep_prop)
+
+# kernel version read
+allow system_app proc_version:file r_file_perms;


### PR DESCRIPTION
01-10 13:30:30.582  4671  4671 W ndroid.settings: type=1400 audit(0.0:33): avc: denied { read } for name=version dev=proc ino=4026532109 scontext=u:r:system_app:s0 tcontext=u:object_r:proc_version:s0 tclass=file permissive=0
01-10 14:01:27.710  3815  3815 W ndroid.settings: type=1400 audit(0.0:33): avc: denied { open } for path="/proc/version" dev="proc" ino=4026532109 scontext=u:r:system_app:s0 tcontext=u:object_r:proc_version:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>