### PR TITLE
system_server: allow writing to timerslack_ns

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -8,12 +8,9 @@ r_dir_file(system_server, idc_file)
 r_dir_file(system_server, keylayout_file)
 r_dir_file(system_server, proc_version)
 
-# TODO(b/30675296): Remove following dontaudit's upon resolution of this bug
-# The timerslack_ns denials spam the system really horribly
-dontaudit system_server audioserver:file write;
-dontaudit system_server untrusted_app:file write;
-dontaudit system_server hal_audio_default:file write;
-dontaudit system_server appdomain:file write;
+# Allow system_server to write to /proc/<pid>/timerslack_ns
+allow system_server appdomain:file w_file_perms;
+allow system_server audioserver:file w_file_perms;
 
 allow system_server proc_cmdline:file r_file_perms;
 allow system_server netmgrd_socket:dir r_dir_perms;


### PR DESCRIPTION
latest aosp sepolicy allows such writes. The rules are based on:
https://android.googlesource.com/platform/system/sepolicy/+/5c41d40ecd3558d44861374c1c490676a224b488
All timerslack_ns related denies are covered by these rules.

Change-Id: Ie78facd3d3cfd2e0c190e03b53804ff098ae684a