### PR TITLE
sepolicy: Correct /odm/bin/sensors.qcom label

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -62,7 +62,7 @@
 /odm/bin/qseecomd                     u:object_r:tee_exec:s0
 /odm/bin/rmt_storage                  u:object_r:rmt_storage_exec:s0
 /odm/bin/sct_service                  u:object_r:sct_exec:s0
-/odm/bin/sensors.qcom                 u:object_r:sensors_exec:s0
+/odm/bin/sensors\.qcom                u:object_r:sensors_exec:s0
 /odm/bin/tad_static                   u:object_r:tad_exec:s0
 /odm/bin/ta_qmi_service               u:object_r:ta_qmi_exec:s0
 /odm/bin/tftp_server                  u:object_r:tad_exec:s0


### PR DESCRIPTION
* '.' is a wildcard for any character, escaping it
  makes sure that only 'sensors.qcom' is being labeled.