### PR TITLE
sepolicy: avoid location denials on loire

### DIFF
--- a/location.te
+++ b/location.te
@@ -7,6 +7,9 @@ allow location sysfs_soc:dir rw_dir_perms;
 allow location sysfs_soc:file r_file_perms;
 allow location sysfs_msm_subsys:dir rw_dir_perms;
 allow location sysfs_msm_subsys:file r_file_perms;
+allow location qmuxd_socket:dir rw_dir_perms;
+allow location qmuxd_socket:sock_file create_file_perms;
+allow location qmuxd:unix_stream_socket connectto;
 
 # /data/vendor/location
 allow location location_data_file:dir create_dir_perms;


### PR DESCRIPTION
04-20 11:07:56.676   656   656 W pcid-lo : type=1400 audit(0.0:22359): avc: denied { search } for name=qmux_gps dev=tmpfs ino=3802 scontext=u:r:location:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=dir permissive=0
01-17 11:18:16.783   652   652 W pcid-lo : type=1400 audit(0.0:6869): avc: denied { write } for name="qmux_gps" dev="tmpfs" ino=3770 scontext=u:r:location:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=dir permissive=0
01-17 11:27:14.234   661   661 W pcid-lo : type=1400 audit(0.0:29): avc: denied { create } for name=716D75785F636C69656E745F736F636B657420202020363631 scontext=u:r:location:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=sock_file permissive=0
01-17 11:34:27.099   702   702 W pcid-lo : type=1400 audit(0.0:35): avc: denied { connectto } for path="/dev/socket/qmux_gps/qmux_connect_socket" scontext=u:r:location:s0 tcontext=u:r:qmuxd:s0 tclass=unix_stream_socket permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>