### PR TITLE
sepolicy: avoid gnss denials

### DIFF
--- a/hal_gnss_qti.te
+++ b/hal_gnss_qti.te
@@ -10,6 +10,7 @@ vndbinder_use(hal_gnss_qti)
 
 allow hal_gnss_qti sysfs_soc:dir r_dir_perms;
 allow hal_gnss_qti sysfs_soc:file r_file_perms;
+allow hal_gnss_qti qmuxd_socket:dir search;
 
 binder_call(hal_gnss_qti, per_mgr)
 allow hal_gnss_qti per_mgr_service:service_manager find;


### PR DESCRIPTION
04-22 01:03:44.222  1048  1048 W Loc_hal : type=1400 audit(0.0:34): avc: denied { search } for name=qmux_radio dev=tmpfs ino=9733 scontext=u:r:hal_gnss_qti:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>