### PR TITLE
sepolicy: avoid camera denials

### DIFF
--- a/hal_camera_default.te
+++ b/hal_camera_default.te
@@ -17,5 +17,5 @@ allow hal_camera_default gpu_device:chr_file rw_file_perms;
 allow hal_camera_default hal_power_default:unix_stream_socket connectto;
 allow hal_camera_default powerhal_socket:sock_file write;
 
-allow hal_camera_default sysfs_msm_subsys:dir search;
+allow hal_camera_default sysfs_msm_subsys:dir rw_dir_perms;
 allow hal_camera_default sysfs_msm_subsys:file r_file_perms;


### PR DESCRIPTION
04-22 00:44:14.222   506   506 W android.hardwar: type=1400 audit(0.0:12): avc: denied { read } for name=devices dev=sysfs ino=22070 scontext=u:r:hal_camera_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>