### PR TITLE
sepolicy: fix selinux status on settings

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -1,3 +1,6 @@
+# SELinux status
+r_dir_file(system_app, selinuxfs)
+
 # ExtendedSettings props
 rw_dir_file(system_app, sysfs_pcc_profile)
 


### PR DESCRIPTION
01-19 12:52:05.260 11724 11724 W ndroid.settings: type=1400 audit(0.0:301): avc: denied { read } for name=enforce dev=selinuxfs ino=4 scontext=u:r:system_app:s0 tcontext=u:object_r:selinuxfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>