### PR TITLE
sepolicy: do not label /proc/cmdline

### DIFF
--- a/file.te
+++ b/file.te
@@ -72,5 +72,3 @@ typeattribute sysfs_batteryinfo mlstrustedobject;
 type proc_irq, fs_type;
 type sysfs_irq, fs_type;
 type irqbalance_socket, file_type;
-
-type proc_cmdline, fs_type;

--- a/genfs_contexts
+++ b/genfs_contexts
@@ -1,5 +1,4 @@
 genfscon proc /irq                                    u:object_r:proc_irq:s0
-genfscon proc /cmdline                                u:object_r:proc_cmdline:s0
 
 genfscon sysfs /devices/soc/soc:qcom,cpubw            u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/soc/soc:qcom,mincpubw         u:object_r:sysfs_msm_subsys:s0

--- a/init.te
+++ b/init.te
@@ -7,8 +7,6 @@ allow init { persist_file qdsp_file }:dir mounton;
 
 dontaudit init kernel:system module_request;
 
-allow init proc_cmdline:file r_file_perms;
-
 #Allow triggering IPA FWs loading
 allow init ipa_dev:chr_file write;
 

--- a/kernel.te
+++ b/kernel.te
@@ -4,5 +4,3 @@ userdebug_or_eng(`
 ')
 
 dontaudit kernel kernel:system module_request;
-
-allow kernel proc_cmdline:file r_file_perms;

--- a/radio.te
+++ b/radio.te
@@ -1,1 +1,0 @@
-allow radio proc_cmdline:file r_file_perms;

--- a/system_server.te
+++ b/system_server.te
@@ -11,7 +11,6 @@ r_dir_file(system_server, keylayout_file)
 allow system_server appdomain:file w_file_perms;
 allow system_server audioserver:file w_file_perms;
 
-allow system_server proc_cmdline:file r_file_perms;
 allow system_server netmgrd_socket:dir r_dir_perms;
 unix_socket_connect(system_server, netmgrd, netmgrd)
 allow system_server self:socket ioctl;

--- a/tad.te
+++ b/tad.te
@@ -6,7 +6,8 @@ init_daemon_domain(tad)
 allow tad block_device:dir { getattr search };
 allow tad ta_block_device:blk_file rw_file_perms;
 
-allow tad proc_cmdline:file r_file_perms;
+# Read access to pseudo filesystems.
+r_dir_file(tad, proc)
 
 ###################
 ### tftp_server ###


### PR DESCRIPTION
label it using aosp selinux via domain_deprecated
https://android.googlesource.com/platform/system/sepolicy/+/android-8.1.0_r7/private/vold.te#2
https://android.googlesource.com/platform/system/sepolicy/+/android-8.1.0_r7/private/domain_deprecated.te#13

04-22 13:35:10.529   479   479 W vold    : type=1400 audit(0.0:5): avc: denied { read } for name=cmdline dev=proc ino=4026532141 scontext=u:r:vold:s0 tcontext=u:object_r:proc_cmdline:s0 tclass=file permissive=0
04-22 09:24:58.426   548   548 W tad_static: type=1400 audit(0.0:5): avc: denied { read } for name="cmdline" dev="proc" ino=4026532141 scontext=u:r:tad:s0 tcontext=u:object_r:proc:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>