### PR TITLE
sepolicy: avoid gnss denials

### DIFF
--- a/hal_gnss_qti.te
+++ b/hal_gnss_qti.te
@@ -10,7 +10,8 @@ vndbinder_use(hal_gnss_qti)
 
 allow hal_gnss_qti sysfs_soc:dir r_dir_perms;
 allow hal_gnss_qti sysfs_soc:file r_file_perms;
-allow hal_gnss_qti qmuxd_socket:dir search;
+allow hal_gnss_qti qmuxd_socket:dir w_dir_perms;
+allow hal_gnss_qti qmuxd_socket:sock_file create_file_perms;
 
 binder_call(hal_gnss_qti, per_mgr)
 allow hal_gnss_qti per_mgr_service:service_manager find;


### PR DESCRIPTION
01-20 00:14:49.542   593   593 W Loc_hal : type=1400 audit(0.0:16): avc: denied { write } for name=qmux_radio dev=tmpfs ino=8292 scontext=u:r:hal_gnss_qti:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=dir permissive=0
01-20 00:35:08.394   588   588 W Loc_hal : type=1400 audit(0.0:18): avc: denied { create } for name=716D75785F636C69656E745F736F636B657420202031323734 scontext=u:r:hal_gnss_qti:s0 tcontext=u:object_r:qmuxd_socket:s0 tclass=sock_file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>