### PR TITLE
sepolicy: allow gnss to connect to qmuxd sockets

### DIFF
--- a/hal_gnss_qti.te
+++ b/hal_gnss_qti.te
@@ -12,6 +12,7 @@ allow hal_gnss_qti sysfs_soc:dir r_dir_perms;
 allow hal_gnss_qti sysfs_soc:file r_file_perms;
 allow hal_gnss_qti qmuxd_socket:dir w_dir_perms;
 allow hal_gnss_qti qmuxd_socket:sock_file create_file_perms;
+unix_socket_connect(hal_gnss_qti, qmuxd, qmuxd)
 
 binder_call(hal_gnss_qti, per_mgr)
 allow hal_gnss_qti per_mgr_service:service_manager find;


### PR DESCRIPTION
This solves the following denial on loire devices:
01-23 01:32:18.863 W/Loc_hal (1994): type=1400 audit(0.0:686): avc: denied { connectto } for path="/dev/socket/qmux_radio/qmux_connect_socket"
scontext=u:r:hal_gnss_qti:s0 tcontext=u:r:qmuxd:s0 tclass=unix_stream_socket permissive=0

Change-Id: I950cce33175c136d21bea5e9b57a487372e84f63