### PR TITLE
Revert "sepolicy: Permit WLAN MAC address activity"

### DIFF
--- a/addrsetup.te
+++ b/addrsetup.te
@@ -12,10 +12,6 @@ allow addrsetup bluetooth_data_file:file create_file_perms;
 allow addrsetup rootfs:lnk_file getattr;
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
-# Permit creation of wlan_mac.bin
-allow addrsetup wifi_data_file:dir rw_dir_perms;
-allow addrsetup wifi_data_file:file create_file_perms;
-
 unix_socket_connect(addrsetup, tad, tad)
 
 allow addrsetup random_device:file read;


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-sepolicy#341

patch is already prezent upstream and can be cherry-picked ec9bc4a7554e54c7bf1a45a1a5b3e65cb429eb70