### PR TITLE
sepolicy: avoid bt denials

### DIFF
--- a/hal_bluetooth_default.te
+++ b/hal_bluetooth_default.te
@@ -1,11 +1,10 @@
 allow hal_bluetooth_default bt_device:chr_file rw_file_perms;
-allow hal_bluetooth_default persist_file:dir search;
-allow hal_bluetooth_default bt_firmware_file:dir search;
-allow hal_bluetooth_default bt_firmware_file:file r_file_perms;
 allow hal_bluetooth_default serial_device:chr_file rw_file_perms;
 
 set_prop(hal_bluetooth_default, wc_prop)
 set_prop(hal_bluetooth_default, bluetooth_prop)
 
+r_dir_file(hal_bluetooth_default, persist_file)
+r_dir_file(hal_bluetooth_default, bt_firmware_file)
 rw_dir_file(hal_bluetooth_default, bluetooth_data_file)
 rw_dir_file(hal_bluetooth_default, sysfs_bluetooth)


### PR DESCRIPTION
09-19 18:15:58.419   619   619 W bluetooth@1.0-s: type=1400 audit(0.0:7): avc: denied { read } for name=.bt_nv.bin dev=sda4 ino=41 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:persist_file:s0 tclass=file permissive=0

also use r_dir_file() macro instead of hardcoding rules

Signed-off-by: David Viteri <davidteri91@gmail.com>