### PR TITLE
sepolicy: avoid system_server denials

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -10,6 +10,7 @@ r_dir_file(system_server, keylayout_file)
 # Allow system_server to write to /proc/<pid>/timerslack_ns
 allow system_server appdomain:file w_file_perms;
 allow system_server audioserver:file w_file_perms;
+allow system_server hal_audio_default:file w_file_perms;
 
 allow system_server netmgrd_socket:dir r_dir_perms;
 unix_socket_connect(system_server, netmgrd, netmgrd)


### PR DESCRIPTION
09-19 18:16:06.789   954   954 W Binder:954_1: type=1400 audit(0.0:8): avc: denied { write } for name=timerslack_ns dev=proc ino=69151 scontext=u:r:system_server:s0 tcontext=u:r:hal_audio_default:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>