### PR TITLE
[master] sony: selinux: Address charger denials

### DIFF
--- a/charger.te
+++ b/charger.te
@@ -1,0 +1,1 @@
+allow charger sysfs_leds:file w_file_perms;


### PR DESCRIPTION
Fix sysfs_leds permission.

avc:  denied  { write } for  pid=465 comm="charger"
name="brightness" dev="sysfs" ino=39679 scontext=u:r:charger:s0
tcontext=u:object_r:sysfs_leds:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Iedfef40f1d9ffe5b056887cc054a5921b3fa0b99