### PR TITLE
sepolicy: avoid pd_mapper denials

### DIFF
--- a/pd_services.te
+++ b/pd_services.te
@@ -5,10 +5,10 @@ init_daemon_domain(pd_mapper);
 
 allow pd_mapper self:capability { setgid setpcap setuid net_bind_service };
 
-allow pd_mapper firmware_file:dir r_dir_perms;
-allow pd_mapper firmware_file:file r_file_perms;
+allow pd_mapper vendor_file:dir r_dir_perms;
 
 allow pd_mapper self:socket create_socket_perms;
 allowxperm pd_mapper self:socket ioctl IPC_ROUTER_IOCTL_BIND_CONTROL_PORT;
 
 r_dir_file(pd_mapper, sysfs_msm_subsys)
+r_dir_file(pd_mapper, firmware_file)


### PR DESCRIPTION
05-21 13:40:44.259   627   627 W pd-mapper: type=1400 audit(0.0:5): avc: denied { read } for name=firmware dev=sda65 ino=2398 scontext=u:r:pd_mapper:s0 tcontext=u:object_r:vendor_file:s0 tclass=dir permissive=0

also use r_dir_file() macro instead of hardcoding rules

Signed-off-by: David Viteri <davidteri91@gmail.com>