### PR TITLE
sepolicy: avoid netmgr denials

### DIFF
--- a/netutils_wrapper.te
+++ b/netutils_wrapper.te
@@ -2,6 +2,8 @@
 allow netutils_wrapper netmgrd:fd use;
 allow netutils_wrapper netmgrd:fifo_file { getattr read write append };
 
+allow netutils_wrapper netmgrd:unix_stream_socket rw_socket_perms;
+
 dontaudit netutils_wrapper netmgrd:netlink_socket { getattr read write append };
 dontaudit netutils_wrapper kernel:system module_request;
 dontaudit netutils_wrapper self:capability sys_module;


### PR DESCRIPTION
01-28 00:43:22.056  6686  6686 W iptables-wrappe: type=1400 audit(0.0:11): avc: denied { read write } for path=socket:[44513] dev=sockfs ino=44513 scontext=u:r:netutils_wrapper:s0 tcontext=u:r:netmgrd:s0 tclass=unix_stream_socket permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>