### PR TITLE
[master] sony: sepolicy: Address thermanager denials

### DIFF
--- a/thermanager.te
+++ b/thermanager.te
@@ -4,5 +4,6 @@ type thermanager_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(thermanager)
 
 rw_dir_file(thermanager, sysfs_devices_system_cpu)
-rw_dir_file(thermanager, sysfs_thermal)
+rw_dir_file(thermanager, sysfs_leds)
 rw_dir_file(thermanager, sysfs_msm_subsys)
+rw_dir_file(thermanager, sysfs_thermal)


### PR DESCRIPTION
Thermal should be able to find and write leds/backlight sysfs.

As logcat says
01-28 00:16:25.647   632   632 I thermanager: "backlight" set to level 0

The trigger for this patch:

avc: denied { search } for name="leds"
dev="sysfs" ino=21689 scontext=u:r:thermanager:s0
tcontext=u:object_r:sysfs_leds:s0 tclass=dir permissive=0

Also sort permissions alphabetically.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I8d63fd3f54190ec06d5d17ccc555febb13a96436