### PR TITLE
[master] system_server: allow writing to timerslack_ns

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -10,6 +10,7 @@ r_dir_file(system_server, keylayout_file)
 # Allow system_server to write to /proc/<pid>/timerslack_ns
 allow system_server appdomain:file w_file_perms;
 allow system_server audioserver:file w_file_perms;
+allow system_server hal_audio_default:file w_file_perms;
 
 allow system_server netmgrd_socket:dir r_dir_perms;
 unix_socket_connect(system_server, netmgrd, netmgrd)


### PR DESCRIPTION
This is an extension of d721910078caf4832389ee2cde48d276366d9ebd

latest aosp sepolicy allows such writes. The rules are based on:
https://android.googlesource.com/platform/system/sepolicy/+/5c41d40ecd3558d44861374c1c490676a224b488
All timerslack_ns related denies are covered by these rules.

avc: denied { write } for name="timerslack_ns" dev="proc"
ino=29102 scontext=u:r:system_server:s0
tcontext=u:r:hal_audio_default:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I5d9a9a874cdb9ceee1a49e839a0858928884fc88