### PR TITLE
[master] sony: sepolicy: Address charger denials

### DIFF
--- a/charger.te
+++ b/charger.te
@@ -1,1 +1,4 @@
+allow charger device:dir r_dir_perms;
+allow charger kernel:system syslog_read;
 allow charger sysfs_leds:file w_file_perms;
+allow charger sysfs_msm_subsys:file w_file_perms;


### PR DESCRIPTION
avc:  denied  { dac_override } for  pid=453 comm="charger"
capability=1  scontext=u:r:charger:s0 tcontext=u:r:charger:s0
tclass=capability permissive=0

avc:  denied  { dac_read_search } for  pid=453 comm="charger"
capability=2  scontext=u:r:charger:s0 tcontext=u:r:charger:s0
tclass=capability permissive=0

avc:  denied  { syslog_read } for  pid=452 comm="charger"
scontext=u:r:charger:s0 tcontext=u:r:kernel:s0
tclass=system permissive=0

avc:  denied  { read } for  pid=451 comm="charger" name="/" dev="tmpfs"
ino=6450 scontext=u:r:charger:s0 tcontext=u:object_r:device:s0
tclass=dir permissive=0

avc:  denied  { write } for  pid=452 comm="charger" name="brightness"
dev="sysfs" ino=25413 scontext=u:r:charger:s0
tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@omnirom.org>
Change-Id: I1674b471ab79cba43666745c2498063f5669adf9