### PR TITLE
sepolicy: re-add selinux for adboverwifi

### DIFF
--- a/property.te
+++ b/property.te
@@ -4,3 +4,4 @@ type net_rmnet_prop, property_type;
 type tee_listener_prop, property_type;
 type wc_prop, property_type;
 type timekeep_prop, property_type;
+type adbtcpes_prop, property_type;

--- a/property_contexts
+++ b/property_contexts
@@ -5,3 +5,4 @@ persist.net.doxlat         u:object_r:net_radio_prop:s0
 sys.listeners.registered   u:object_r:tee_listener_prop:s0
 wc_transport.              u:object_r:wc_prop:s0
 persist.sys.timeadjust     u:object_r:timekeep_prop:s0
+adb.network.port.es        u:object_r:adbtcpes_prop:s0

--- a/system_app.te
+++ b/system_app.te
@@ -3,6 +3,7 @@ r_dir_file(system_app, selinuxfs)
 
 # ExtendedSettings props
 rw_dir_file(system_app, sysfs_pcc_profile)
+set_prop(system_app, adbtcpes_prop)
 
 # TimeKeep Java service
 allow system_app timekeep_vendor_data_file:dir create_dir_perms;


### PR DESCRIPTION
selinux was removed in commit 14fe403ac06cdb2d1338795a9f6dc169f0a54f19 and it is needed for devices working under enforcing selinux

Signed-off-by: David Viteri <davidteri91@gmail.com>