### PR TITLE
sepolicy: avoid wlan denials

### DIFF
--- a/file.te
+++ b/file.te
@@ -72,3 +72,6 @@ typeattribute sysfs_batteryinfo mlstrustedobject;
 type proc_irq, fs_type;
 type sysfs_irq, fs_type;
 type irqbalance_socket, file_type;
+
+# /sys/kernel/boot_wlan/boot_wlan
+type sysfs_boot_wlan, fs_type, sysfs_type;

--- a/file_contexts
+++ b/file_contexts
@@ -38,6 +38,9 @@
 /dev/socket/powerhal(/.*)?                      u:object_r:powerhal_socket:s0
 /dev/socket/tad                                 u:object_r:tad_socket:s0
 
+# sysfs files
+/sys/kernel/boot_wlan/boot_wlan                 u:object_r:sysfs_boot_wlan:s0
+
 # files in /system
 /(system|vendor)/rfs.*                         u:object_r:rfs_system_file:s0
 /(system/vendor|vendor)/bin/macaddrsetup       u:object_r:addrsetup_exec:s0

--- a/hal_wifi_default.te
+++ b/hal_wifi_default.te
@@ -1,0 +1,2 @@
+# /sys/kernel/boot_wlan/boot_wlan
+allow hal_wifi_default sysfs_boot_wlan:file w_file_perms;


### PR DESCRIPTION
03-15 11:27:28.095   633   633 W android.hardwar: type=1400 audit(0.0:38): avc: denied { write } for name=boot_wlan dev=sysfs ino=44284 scontext=u:r:hal_wifi_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>