### PR TITLE
sepolicy: Add rules for persist.dispcal.setting

### DIFF
--- a/property.te
+++ b/property.te
@@ -5,3 +5,4 @@ type tee_listener_prop, property_type;
 type wc_prop, property_type;
 type timekeep_prop, property_type;
 type adbtcpes_prop, property_type;
+type dispcal_prop, property_type;

--- a/property_contexts
+++ b/property_contexts
@@ -6,3 +6,4 @@ sys.listeners.registered   u:object_r:tee_listener_prop:s0
 wc_transport.              u:object_r:wc_prop:s0
 persist.sys.timeadjust     u:object_r:timekeep_prop:s0
 adb.network.port.es        u:object_r:adbtcpes_prop:s0
+persist.dispcal.setting    u:object_r:dispcal_prop:s0

--- a/system_app.te
+++ b/system_app.te
@@ -4,6 +4,7 @@ r_dir_file(system_app, selinuxfs)
 # ExtendedSettings props
 rw_dir_file(system_app, sysfs_pcc_profile)
 set_prop(system_app, adbtcpes_prop)
+set_prop(system_app, dispcal_prop)
 
 # TimeKeep Java service
 allow system_app timekeep_vendor_data_file:dir create_dir_perms;


### PR DESCRIPTION
This fixes:
[  174.166672] selinux: avc:  denied  { set } for property=persist.dispcal.setting pid=2319 uid=1000 gid=1000 scontext=u:r:system_app:s0 tcontext=u:object_r:default_prop:s0 tclass=property_service permissive=0\x0a
[  174.170856] init: sys_prop(PROP_MSG_SETPROP2): permission denied uid:1000 name:persist.dispcal.setting

Change-Id: I23a287f765a6fcb2e39016205c3e2848914a1b34