### PR TITLE
sepolicy: avoid pd_services denials

### DIFF
--- a/pd_services.te
+++ b/pd_services.te
@@ -5,7 +5,7 @@ init_daemon_domain(pd_mapper);
 
 allow pd_mapper self:capability { setgid setpcap setuid net_bind_service };
 
-allow pd_mapper vendor_firmware_file:dir r_dir_perms;
+allow pd_mapper { vendor_firmware_file vendor_file }:dir r_dir_perms;
 
 allow pd_mapper self:socket create_socket_perms;
 allowxperm pd_mapper self:socket ioctl IPC_ROUTER_IOCTL_BIND_CONTROL_PORT;


### PR DESCRIPTION
[   12.422295] type=1400 audit(16689756.629:5): avc: denied { read } for pid=648 comm=pd-mapper name=firmware dev=sda65 ino=2420 scontext=u:r:pd_mapper:s0 tcontext=u:object_r:vendor_file:s0 tclass=dir permissive=0

support was removed in commit 0174e9cd3f0ceee90af83fd27b281aa4a2110319

Signed-off-by: David Viteri <davidteri91@gmail.com>