### PR TITLE
sepolicy: Label HIDL fingerprint HAL

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -50,6 +50,7 @@
 /(system/vendor|vendor)/bin/thermanager                                 u:object_r:thermanager_exec:s0
 /(system/vendor|vendor)/bin/timekeep                                    u:object_r:timekeep_exec:s0
 /(system/vendor|vendor)/bin/odmcheck                                    u:object_r:odmcheck_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.biometrics\.fingerprint@2\.1-service\.sony u:object_r:hal_fingerprint_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@1\.0-service-qti u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony u:object_r:hal_light_default_exec:s0
 


### PR DESCRIPTION
* Since we switched to HIDL implementation we
  got to label our new service so that it's able
  to start.

Change-Id: I0b2efe50b77d70bd6b130047897823145c2193ab