### PR TITLE
sepolicy: avoid drmserver denials

### DIFF
--- a/drmserver.te
+++ b/drmserver.te
@@ -1,0 +1,1 @@
+allow drmserver sdcardfs:dir r_dir_perms;


### PR DESCRIPTION
04-10 13:21:27.096  1054  1054 W Binder:1054_1: type=1400 audit(0.0:16): avc: denied { read } for path=/storage/4EDD-36C3/Android/data dev=sdcardfs ino=3 scontext=u:r:drmserver:s0 tcontext=u:object_r:sdcardfs:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>