### PR TITLE
sepolicy: avoid mdss_rotator denials

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -17,6 +17,7 @@
 /dev/qseecom                                    u:object_r:tee_device:s0
 /dev/jpeg[0-9]*                                 u:object_r:video_device:s0
 /dev/adsprpc-smd                                u:object_r:qdsp_device:s0
+/dev/mdss_rotator                               u:object_r:graphics_device:s0
 /dev/msm_.*                                     u:object_r:audio_device:s0
 /dev/avtimer                                    u:object_r:avtimer_device:s0
 /dev/subsys_.*                                  u:object_r:ssr_device:s0

--- a/hal_graphics_composer_default.te
+++ b/hal_graphics_composer_default.te
@@ -3,7 +3,7 @@ vndbinder_use(hal_graphics_composer_default)
 allow hal_graphics_composer_default qdisplay_service:service_manager { add find };
 
 allow hal_graphics_composer_default sysfs_mdss_mdp_caps:file r_file_perms;
-allow hal_graphics_composer_default video_device:chr_file rw_file_perms;
+allow hal_graphics_composer_default { graphics_device video_device }:chr_file rw_file_perms;
 
 r_dir_file(hal_graphics_composer_default, sysfs_leds)
 r_dir_file(hal_graphics_composer_default, sysfs_camera)


### PR DESCRIPTION
07-13 15:17:02.989   515   515 W android.hardwar: type=1400 audit(0.0:4): avc: denied { read write } for name=mdss_rotator dev=tmpfs ino=7728 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>