### PR TITLE
sepolicy: avoid idmap denials

### DIFF
--- a/idmap.te
+++ b/idmap.te
@@ -1,0 +1,1 @@
+allow idmap installd:file r_file_perms;


### PR DESCRIPTION
04-18 11:15:47.179  1486  1486 W idmap   : type=1400 audit(0.0:5): avc: denied { read } for path=/proc/806/mounts dev=proc ino=21078 scontext=u:r:idmap:s0 tcontext=u:r:installd:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>