### PR TITLE
avoid init denials

### DIFF
--- a/init.te
+++ b/init.te
@@ -4,6 +4,7 @@ allow init configfs:file rw_file_perms;
 allow init configfs:lnk_file { create unlink };
 
 allow init { firmware_file bt_firmware_file persist_file qdsp_file }:dir mounton;
+allow init proc_irq:file w_file_perms;
 
 dontaudit init kernel:system module_request;
 


### PR DESCRIPTION
12-31 17:13:46.650     1     1 W init    : type=1400 audit(0.0:4): avc: denied { write } for name=default_smp_affinity dev=proc ino=4026531865 scontext=u:r:init:s0 tcontext=u:object_r:proc_irq:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>