### PR TITLE
[SEPOLICY] Add support for the Camera Augmented Sensing Helper Server

### DIFF
--- a/cashsvr.te
+++ b/cashsvr.te
@@ -1,0 +1,7 @@
+type cashsvr, domain;
+type cashsvr_exec, exec_type, vendor_file_type, file_type;
+
+allow cashsvr cashsvr_socket:dir rw_dir_perms;
+allow cashsvr cashsvr_socket:sock_file create_file_perms;
+
+init_daemon_domain(cashsvr)

--- a/file.te
+++ b/file.te
@@ -31,6 +31,7 @@ type location_data_file, file_type, data_file_type;
 type qmuxd_socket, file_type;
 type netmgrd_socket, file_type;
 type powerhal_socket, file_type;
+type cashsvr_socket, file_type;
 type qdsp_file, file_type, mlstrustedobject;
 type tad_socket, file_type;
 

--- a/file_contexts
+++ b/file_contexts
@@ -39,6 +39,7 @@
 /dev/socket/netmgr(/.*)?                        u:object_r:netmgrd_socket:s0
 /dev/socket/powerhal(/.*)?                      u:object_r:powerhal_socket:s0
 /dev/socket/tad                                 u:object_r:tad_socket:s0
+/dev/socket/cashsvr(/.*)?                       u:object_r:cashsvr_socket:s0
 
 # files in /odm
 /odm/bin/hw/android\.hardware\.keymaster@3\.0-service-qti u:object_r:hal_keymaster_qti_exec:s0
@@ -74,6 +75,7 @@
 /(system/vendor|vendor)/bin/init\.qcom\.ipastart\.sh                                         u:object_r:init-qcom-ipastart-sh_exec:s0
 /(system/vendor|vendor)/bin/initlight                                                        u:object_r:initlight_exec:s0
 /(system/vendor|vendor)/bin/ucommsvr                                                         u:object_r:ucommsvr_exec:s0
+/(system/vendor|vendor)/bin/cashsvr                                                          u:object_r:cashsvr_exec:s0
 /(system/vendor|vendor)/bin/thermanager                                                      u:object_r:thermanager_exec:s0
 /(system/vendor|vendor)/bin/timekeep                                                         u:object_r:timekeep_exec:s0
 /(system/vendor|vendor)/bin/odmcheck                                                         u:object_r:odmcheck_exec:s0

--- a/hal_camera_default.te
+++ b/hal_camera_default.te
@@ -18,6 +18,10 @@ allow hal_camera_default hal_power_default:unix_stream_socket connectto;
 allow hal_camera_default powerhal_socket:dir search;
 allow hal_camera_default powerhal_socket:sock_file write;
 
+allow hal_camera_default cashsvr:unix_stream_socket connectto;
+allow hal_camera_default cashsvr_socket:dir search;
+allow hal_camera_default cashsvr_socket:sock_file write;
+
 allow hal_camera_default sysfs_msm_subsys:dir rw_dir_perms;
 allow hal_camera_default sysfs_msm_subsys:file r_file_perms;
 r_dir_file(hal_camera_default, sysfs_soc)


### PR DESCRIPTION
Needs context and permission to read input devices, search,
read and write its own sockets.

Also needs camera HAL to access its socket.