### PR TITLE
avoid wifi denials

### DIFF
--- a/hal_wifi_default.te
+++ b/hal_wifi_default.te
@@ -1,2 +1,4 @@
 # /sys/kernel/boot_wlan/boot_wlan
 allow hal_wifi_default sysfs_boot_wlan:file w_file_perms;
+
+allow hal_wifi_default kernel:system module_request;


### PR DESCRIPTION
[   16.327338] type=1400 audit(1526281929.309:4): avc: denied { module_request } for pid=675 comm=android.hardwar kmod=net-pf-16-proto-16-family-cld80211 scontext=u:r:hal_wifi_default:s0 tcontext=u:r:kernel:s0 tclass=system permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>