### PR TITLE
[DNM] cash: setup selinux for new permissions management

### DIFF
--- a/cashsvr.te
+++ b/cashsvr.te
@@ -3,6 +3,8 @@ type cashsvr_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(cashsvr)
 
+allow cashsvr self:capability { chown setuid };
+
 allow cashsvr cashsvr_socket:dir rw_dir_perms;
 allow cashsvr cashsvr_socket:sock_file create_file_perms;
 
@@ -12,5 +14,5 @@ allow cashsvr sysfs_msm_subsys:file r_file_perms;
 allow cashsvr input_device:dir search;
 allow cashsvr input_device:chr_file r_file_perms;
 
-allow cashsvr sysfs_tof_sensor:file rw_file_perms;
+allow cashsvr sysfs_tof_sensor:file { rw_file_perms setattr };
 allow cashsvr sysfs:file r_file_perms;


### PR DESCRIPTION
Properly fix the sysfs node permissions as well as assigning the proper uid to cash from inside cash.

Change-Id: Idcfd79afe55a50084e98f16f29c30f5ca4f426d5