### PR TITLE
sepolicy: avoid camera denials

### DIFF
--- a/hal_camera_default.te
+++ b/hal_camera_default.te
@@ -1,7 +1,10 @@
 vndbinder_use(hal_camera_default);
-allow hal_camera_default qdisplay_service:service_manager { find };
+allow hal_camera_default qdisplay_service:service_manager find;
 
-allow hal_camera_default hal_graphics_mapper_hwservice:hwservice_manager find;
+allow hal_camera_default {
+     fwk_display_hwservice
+     hal_graphics_mapper_hwservice
+}:hwservice_manager find;
 
 binder_call(hal_camera_default, hal_graphics_composer)
 binder_call(hal_camera_default, system_server)

--- a/surfaceflinger.te
+++ b/surfaceflinger.te
@@ -1,5 +1,8 @@
 dontaudit surfaceflinger firmware_file:dir search;
 dontaudit surfaceflinger kernel:system module_request;
+
 allow surfaceflinger debugfs_ion:dir search;
 
 rw_dir_file(surfaceflinger, sysfs_graphics)
+
+binder_call(surfaceflinger, hal_camera_default)


### PR DESCRIPTION
05-20 13:09:36.149   581   581 E SELinux : avc:  denied  { find } for interface=android.frameworks.displayservice::IDisplayService pid=670 scontext=u:r:hal_camera_default:s0 tcontext=u:object_r:fwk_display_hwservice:s0 tclass=hwservice_manager permissive=0
05-20 13:29:05.009   684   684 W HwBinder:684_1: type=1400 audit(0.0:4): avc: denied { call } for scontext=u:r:surfaceflinger:s0 tcontext=u:r:hal_camera_default:s0 tclass=binder permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>