### PR TITLE
sepolicy: remove legacy /data/misc/netmgr folder

### DIFF
--- a/file_contexts
+++ b/file_contexts
@@ -123,7 +123,6 @@
 # data files
 # TODO: Modify binaries to use /data/vendor/*
 /data/time(/.*)?                       u:object_r:timekeep_vendor_data_file:s0
-/data/misc/netmgr(/.*)?                u:object_r:netmgr_data_file:s0
 /data/misc/radio(/.*)?                 u:object_r:radio_vendor_data_file:s0
 /data/misc/sensors(/.*)?               u:object_r:sensors_vendor_data_file:s0
 /data/vendor/netmgr(/.*)?              u:object_r:netmgr_data_file:s0


### PR DESCRIPTION
all the things were move to /data/vendor/netmgr and we should not add permissions
for the old location

Signed-off-by: David Viteri <davidteri91@gmail.com>