### PR TITLE
sepolicy: avoid DRS denials

### DIFF
--- a/system_app.te
+++ b/system_app.te
@@ -2,6 +2,7 @@
 r_dir_file(system_app, selinuxfs)
 
 # ExtendedSettings props
+rw_dir_file(system_app, sysfs_graphics)
 rw_dir_file(system_app, sysfs_pcc_profile)
 set_prop(system_app, adbtcpes_prop)
 set_prop(system_app, dispcal_prop)


### PR DESCRIPTION
06-16 00:10:29.977 10073 10073 W xtendedsettings: type=1400 audit(0.0:29): avc: denied { write } for name=mode dev=sysfs ino=34050 scontext=u:r:system_app:s0 tcontext=u:object_r:sysfs_graphics:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>