### PR TITLE
sepolicy: avoid recovery denials

### DIFF
--- a/recovery.te
+++ b/recovery.te
@@ -1,0 +1,5 @@
+recovery_only(`
+  allow recovery sysfs_msm_subsys:dir search;
+  allow recovery sysfs_fs_ext4_features:dir search;
+  allow recovery sysfs_fs_ext4_features:file r_file_perms;
+')


### PR DESCRIPTION
poplar:/cache/recovery # cat last_kmsg | grep avc
<5>[    1.768711] audit: type=1400 audit(24497544.774:5): avc:  denied  { search } for  pid=530 comm=recovery name=c900000.qcom,mdss_mdp dev=sysfs ino=24070 scontext=u:r:recovery:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=dir permissive=0
<5>[   27.251991] audit: type=1400 audit(24497570.257:6): avc:  denied  { search } for  pid=567 comm=mke2fs_static name=features dev=sysfs ino=32760 scontext=u:r:recovery:s0 tcontext=u:object_r:sysfs_fs_ext4_features:s0 tclass=dir permissive=0
<5>[   29.808838] audit: type=1400 audit(24500789.794:5): avc:  denied  { read } for  pid=583 comm="mke2fs_static" name="lazy_itable_init" dev="sysfs" ino=32761 scontext=u:r:recovery:s0 tcontext=u:object_r:sysfs_fs_ext4_features:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>