### PR TITLE
sepolicy: avoid kernel 4.9 denials

### DIFF
--- a/hal_wifi_supplicant_default.te
+++ b/hal_wifi_supplicant_default.te
@@ -1,0 +1,1 @@
+allow hal_wifi_supplicant_default proc_net:file w_file_perms;

--- a/netd.te
+++ b/netd.te
@@ -1,5 +1,6 @@
-allow netd sysfs_net:file w_file_perms;
+allow netd sysfs_net:file create_file_perms;
 allow netd sysfs_net:dir w_dir_perms;
+allow netd proc_net:file create_file_perms;
 allow netd proc_net:dir w_dir_perms;
 
 dontaudit netd kernel:system module_request;


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>