### PR TITLE
sepolicy: remove double def

### DIFF
--- a/file.te
+++ b/file.te
@@ -6,14 +6,12 @@ type sysfs_graphics, sysfs_type, fs_type;
 type sysfs_mdss_mdp_caps, sysfs_type, fs_type;
 type sysfs_msm_subsys, sysfs_type, fs_type;
 type sysfs_msm_subsys_restart, sysfs_type, fs_type;
-type sysfs_net, sysfs_type, fs_type;
 type sysfs_rmtfs, sysfs_type, fs_type;
 type sysfs_soc, sysfs_type, fs_type;
 type sysfs_timestamp_switch, sysfs_type, fs_type;
 type sysfs_addrsetup, sysfs_type, fs_type;
 type sysfs_bluetooth, sysfs_type, fs_type;
 type sysfs_pcc_profile, sysfs_type, fs_type;
-type sysfs_rtc, sysfs_type, fs_type;
 type sysfs_timekeep, sysfs_type, fs_type;
 
 type debugfs_clk, debugfs_type, fs_type;


### PR DESCRIPTION
those are already defined on https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r1/public/file.te

Signed-off-by: David Viteri <davidteri91@gmail.com>