### PR TITLE
Pie/4.9: Sepolicy cleanups

### DIFF
--- a/file.te
+++ b/file.te
@@ -67,8 +67,8 @@ type keylayout_file, file_type, vendor_file_type;
 typeattribute sysfs_batteryinfo mlstrustedobject;
 
 # msm_irqbalance
-type proc_irq, proc_type;
-type sysfs_irq, sysfs_type;
+type proc_irq, proc_type, fs_type;
+type sysfs_irq, sysfs_type, fs_type;
 type irqbalance_socket, file_type;
 
 # /sys/kernel/boot_wlan/boot_wlan

--- a/genfs_contexts
+++ b/genfs_contexts
@@ -33,6 +33,7 @@ genfscon sysfs /devices/soc0                                            u:object
 genfscon sysfs /bus/msm_subsys                                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /module/subsystem_restart                                u:object_r:sysfs_msm_subsys_restart:s0
 genfscon sysfs /kernel/boot_adsp/boot                                   u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /kernel/boot_cdsp/boot                                   u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /kernel/boot_slpi/boot                                   u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /module/msm_performance                                  u:object_r:sysfs_msm_subsys:s0
 

--- a/init-devstart-sh.te
+++ b/init-devstart-sh.te
@@ -8,7 +8,7 @@ allow init-qcom-devstart-sh { vendor_file vendor_shell_exec vendor_toolbox_exec 
 # Set the sys.qcom.devup property
 set_prop(init-qcom-devstart-sh, system_prop)
 
-# Set boot_adsp and boot_slpi to 1
+# Set boot_adsp, boot_cdsp and boot_slpi to 1
 allow init-qcom-devstart-sh sysfs_msm_subsys:file w_file_perms;
 
 r_dir_rw_file(init-qcom-devstart-sh, sysfs)

--- a/init-devstart-sh.te
+++ b/init-devstart-sh.te
@@ -11,4 +11,5 @@ set_prop(init-qcom-devstart-sh, system_prop)
 # Set boot_adsp, boot_cdsp and boot_slpi to 1
 allow init-qcom-devstart-sh sysfs_msm_subsys:file w_file_perms;
 
-r_dir_rw_file(init-qcom-devstart-sh, sysfs)
+# Ignore O_CREAT flag in bash file redirection:
+dontaudit init-qcom-devstart-sh sysfs_msm_subsys:file create;

--- a/init.te
+++ b/init.te
@@ -7,17 +7,11 @@ allow init { firmware_file bt_firmware_file persist_file qdsp_file }:dir mounton
 
 dontaudit init kernel:system module_request;
 
-# init_power.te
-# TODO: Test necesssity
-# r_dir_rw_file(init, sysfs_devices_system_cpu)
-# allow init sysfs_devices_system_cpu:file create;
+# Ignore all accidental O_CREAT open() calls on unsupported filesystems:
+dontaudit init { sysfs_type proc_type }:file create;
 
-allow init cgroup:file rw_file_perms;
+# Allow the init process to read and write default_smp_affinity:
+allow init proc_irq:file rw_file_perms;
 
-# TODO: This is not the right substitution.
-r_dir_rw_file(init, proc_irq)
-
-# TODO: File creation on sysfs?
-allow init sysfs_msm_subsys:file create;
-allow init sysfs_msm_subsys_restart:file create;
-allow init sysfs_zram:file create;
+# enable_ramdumps:
+allow init sysfs_msm_subsys_restart:file rw_file_perms;

--- a/msm_irqbalanced.te
+++ b/msm_irqbalanced.te
@@ -5,8 +5,12 @@ init_daemon_domain(msm_irqbalanced);
 
 allow msm_irqbalanced self:capability { setgid setuid };
 
+# Allow to read and write files in /sys/devices/system/cpu/:
 allow msm_irqbalanced sysfs_devices_system_cpu:file rw_file_perms;
+
+# Allow msm_irqbalanced to search irq and set SMP affinity:
 r_dir_rw_file(msm_irqbalanced, proc_irq)
+
 allow msm_irqbalanced sysfs_irq:file r_file_perms;
 allow msm_irqbalanced proc_stat:file r_file_perms;
 allow msm_irqbalanced proc_interrupts:file r_file_perms;

--- a/netd.te
+++ b/netd.te
@@ -1,2 +1,3 @@
 dontaudit netd kernel:system module_request;
 dontaudit netd self:capability sys_module;
+dontaudit netd proc_net:dir write;

--- a/tad.te
+++ b/tad.te
@@ -58,10 +58,6 @@ allow tad self:capability {
     net_bind_service
 };
 
-# RFS UID and GIDs were changed and moved from old values to new ones OEM range.
-# The below permissions are required to recursively update the folder ownership
-# to the new values in the OEM range.
-
 #For access to the kmsg device
 allow tad kmsg_device:chr_file w_file_perms;
 

--- a/zygote.te
+++ b/zygote.te
@@ -1,1 +1,0 @@
-allow zygote cgroup:file rw_file_perms;


### PR DESCRIPTION
This pull request contains cleanups and comments to finish off cherry-picking #396.

Regressions from previous *WIP* pull request that need to be addressed outside of the SEPolicy:
- msm_irqbalance with `DAC_OVERRIDE` permission:
  Granting this permission is not allowed anymore since Pie, and not even needed. The init script starts the process as root user, and all the files it needs to access are owned by root with permission `600`.
  The capset call it does to acquire DAC_OVERRIDE (`capset({version=_LINUX_CAPABILITY_VERSION_1, pid=0}, {effective=1<<CAP_DAC_OVERRIDE, permitted=1<<CAP_DAC_OVERRIDE, inheritable=0}) = 0`) can thus be removed entirely.
  However, every once in a while the init script starts the executable with group and user `nobody`, which might explain the initial reason to use `CAP_DAC_OVERRIDE`.

Test: Build-tested on Pie, tested for a few days on Suzu with kernel 4.9 on Oreo.

Final word of confusion: depending on the context O_CREAT causes either a `dir write` or `file create` denial: if someone knows the reason for this, please let me know!