### PR TITLE
FULL_TREBLE regression fixes

### DIFF
--- a/addrsetup.te
+++ b/addrsetup.te
@@ -5,4 +5,6 @@ init_daemon_domain(addrsetup)
 
 unix_socket_connect(addrsetup, tad, tad)
 
+allow addrsetup { wifi_data_file bluetooth_data_file }:file create_file_perms;
+
 allow addrsetup sysfs_addrsetup:file rw_file_perms;

--- a/rild.te
+++ b/rild.te
@@ -10,3 +10,5 @@ allowxperm rild self:socket ioctl msm_sock_ipc_ioctls;
 
 allow rild radio_vendor_data_file:dir rw_dir_perms;
 allow rild radio_vendor_data_file:file create_file_perms;
+
+allow rild radio_data_file:dir r_dir_perms;

--- a/rild.te
+++ b/rild.te
@@ -7,3 +7,6 @@ unix_socket_connect(rild, netmgrd, netmgrd)
 
 allow rild self:socket ioctl;
 allowxperm rild self:socket ioctl msm_sock_ipc_ioctls;
+
+allow rild radio_vendor_data_file:dir rw_dir_perms;
+allow rild radio_vendor_data_file:file create_file_perms;

--- a/sensors.te
+++ b/sensors.te
@@ -18,6 +18,9 @@ allow sensors persist_sensors_file:dir rw_dir_perms;
 allow sensors persist_sensors_file:file create_file_perms;
 allow sensors persist_file:dir { getattr search };
 
+allow sensors sensors_vendor_data_file:dir rw_dir_perms;
+allow sensors sensors_vendor_data_file:file create_file_perms;
+
 allow sensors system_file:dir r_dir_perms;
 allow sensors sensors_device:chr_file rw_file_perms;
 

--- a/timekeep.te
+++ b/timekeep.te
@@ -6,6 +6,9 @@ init_daemon_domain(timekeep)
 # Grant permission to set system time and to set the real-time lock
 allow timekeep self:capability { fowner sys_time };
 
+allow timekeep timekeep_vendor_data_file:dir rw_dir_perms;
+allow timekeep timekeep_vendor_data_file:file create_file_perms;
+
 set_prop(timekeep, timekeep_prop)
 
 r_dir_file(timekeep, sysfs_msm_subsys)


### PR DESCRIPTION
These commits fix a bunch of regressions caused by removing "erroneous" lines after enabling `PRODUCT_FULL_TREBLE` (through setting `PRODUCT_SHIPPING_API_LEVEL`).

All commits succeed `m sepolicy_tests` with `PRODUCT_SHIPPING_API_LEVEL` set to either `26` or `27`.

There are still more regressions left to fix which require modifications to closed-source oem images; a common one being vendor applications not allowed access to `binder` anymore.