### PR TITLE
sony: sepolicy: Address vendor_init denials

### DIFF
--- a/vendor_init.te
+++ b/vendor_init.te
@@ -1,0 +1,16 @@
+allow vendor_init {
+    audio_data_file
+    bluetooth_data_file
+    camera_data_file
+    dhcp_data_file
+    radio_vendor_data_file
+    rootfs
+    sensors_vendor_data_file
+    system_data_file
+    wifi_data_file
+}:dir create_dir_perms;
+
+allow vendor_init device:file create_file_perms;
+allow vendor_init kernel:system { module_request };
+allow vendor_init proc:file rw_file_perms;
+allow vendor_init radio_vendor_data_file:file create_file_perms;


### PR DESCRIPTION
avc: denied { setattr } for pid=430 comm="init" name="audio" dev="dm-1"
ino=188094 scontext=u:r:vendor_init:s0 tcontext=u:object_r:audio_data_file:s0
tclass=dir permissive=0

avc: denied { setattr } for pid=430 comm="init" name="bluetooth" dev="tmpfs"
ino=2938 scontext=u:r:vendor_init:s0 tcontext=u:object_r:bluetooth_data_file:s0
tclass=dir permissive=0

avc: denied { setattr } for pid=430 comm="init" name="dhcp" dev="tmpfs" ino=2962
scontext=u:r:vendor_init:s0 tcontext=u:object_r:dhcp_data_file:s0 tclass=dir
permissive=0

avc: denied { write } for pid=430 comm="init" name="/" dev="tmpfs" ino=17429
scontext=u:r:vendor_init:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir
permissive=0

avc: denied { setattr } for pid=430 comm="init" name="wifi" dev="tmpfs" ino=2958
scontext=u:r:vendor_init:s0 tcontext=u:object_r:wifi_data_file:s0
tclass=dir permissive=0

avc:  denied  { write } for  pid=426 comm="init" name="/" dev="rootfs" ino=2
scontext=u:r:vendor_init:s0 tcontext=u:object_r:rootfs:s0 tclass=dir
permissive=0

avc:  denied  { add_name } for  pid=426 comm="init" name="tmp"
scontext=u:r:vendor_init:s0 tcontext=u:object_r:rootfs:s0 tclass=dir
permissive=0

avc: denied { add_name } for pid=427 comm="init" name="hostapd"
scontext=u:r:vendor_init:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir
permissive=0

avc:  denied  { create } for  pid=426 comm="init" name="tmp"
scontext=u:r:vendor_init:s0 tcontext=u:object_r:rootfs:s0 tclass=dir
permissive=0

avc:  denied  { module_request } for  pid=426 comm="init" kmod="crypto-lz4"
scontext=u:r:vendor_init:s0 tcontext=u:r:kernel:s0 tclass=system permissive=0

avc: denied { setattr } for pid=427 comm="init" name="camera" dev="dm-1"
ino=188097 scontext=u:r:vendor_init:s0 tcontext=u:object_r:camera_data_file:s0
tclass=dir permissive=0

avc: denied { setattr } for pid=427 comm="init" name="sensors" dev="dm-1"
ino=188104 scontext=u:r:vendor_init:s0
tcontext=u:object_r:sensors_vendor_data_file:s0 tclass=dir permissive=0

avc: denied { write } for pid=427 comm="init" name="radio" dev="tmpfs" ino=16703
scontext=u:r:vendor_init:s0 tcontext=u:object_r:radio_vendor_data_file:s0
tclass=dir permissive=0

avc: denied { write } for name="sched_boost" dev="proc"
ino=24526 scontext=u:r:vendor_init:s0 tcontext=u:object_r:proc:s0
tclass=file permissive=0

avc: denied { create } for pid=429 comm="init" name="copy_complete"
scontext=u:r:vendor_init:s0 tcontext=u:object_r:radio_vendor_data_file:s0
tclass=file permissive=0

avc: denied { create } for pid=429 comm="init" name="cpus"
scontext=u:r:vendor_init:s0 tcontext=u:object_r:device:s0
tclass=file permissive=0

Change-Id: I63c7e8f3ab3dfdb534a0c94e80d9ebbf2adb0a38
Signed-off-by: Humberto Borba <humberos@omnirom.org>