### PR TITLE
sony: sepolicy: Add basic USB HAL context

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -88,6 +88,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@1\.1-service-qti                      u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.1-service\.clearkey                 u:object_r:hal_drm_clearkey_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.usb@1\.0-service\.basic                    u:object_r:hal_usb_default_exec:s0
 
 # sysfs paths
 /sys/devices/virtual/input/input[0-9]+/enable_ps_sensor                                      u:object_r:sysfs_tof_sensor:s0


### PR DESCRIPTION
Change-Id: I0de04e869c607178677b7fc82ce2f12bd266d8a1
Signed-off-by: Humberto Borba <humberos@omnirom.org>