### PR TITLE
Add batteryinfo capabilities to charger

### DIFF
--- a/vendor/charger.te
+++ b/vendor/charger.te
@@ -1,3 +1,4 @@
 allow charger device:dir r_dir_perms;
 allow charger kernel:system syslog_read;
 allow charger sysfs_msm_subsys:file w_file_perms;
+allow charger sysfs_batteryinfo:file r_file_perms;


### PR DESCRIPTION
`healthd` already has `sysfs_batteryinfo` caps and `charger` should use them them as well.

This is needed for accessing `/sys/devices/platform/soc/75b9000.i2c/i2c-11/11-0025/power_supply/typec/type` on tone for which I have specified `sysfs_batteryinfo` in https://github.com/sonyxperiadev/device-sony-tone/pull/150.

<strike>The `wake_alarm` capability may not be needed in normal operation, I have only seen it requested in conjunction with fpc crashes. Please discuss.</strik>