### PR TITLE
Add contexts for wakeup_gesture for double-tap-to-wake

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -14,6 +14,7 @@ type sysfs_bluetooth, sysfs_type, fs_type;
 type sysfs_pcc_profile, sysfs_type, fs_type;
 type sysfs_timekeep, sysfs_type, fs_type;
 type sysfs_usb_supply, sysfs_type, fs_type;
+type sysfs_input_wakeup, sysfs_type, fs_type;
 
 type debugfs_clk, debugfs_type, fs_type;
 type debugfs_ion, debugfs_type, fs_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -94,6 +94,9 @@
 /sys/devices/virtual/input/input[0-9]+/enable_ps_sensor                                      u:object_r:sysfs_tof_sensor:s0
 /sys/devices/virtual/input/input[0-9]+/set_use_case                                          u:object_r:sysfs_tof_sensor:s0
 
+# double-tap-to-wake
+/sys/devices/virtual/input/input[0-9]+/wakeup_gesture                                        u:object_r:sysfs_input_wakeup:s0
+
 ###############################################
 # same-process HAL files and their dependencies
 #

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -2,3 +2,4 @@ allow hal_power_default powerhal_socket:dir rw_dir_perms;
 allow hal_power_default powerhal_socket:sock_file create_file_perms;
 
 allow hal_power_default sysfs_devices_system_cpu:file w_file_perms;
+allow hal_power_default sysfs_input_wakeup:file rw_file_perms;


### PR DESCRIPTION
Not urgent, but I have double-tap-to-wake enabled on my builds and if we eventually fix the deep sleep issue, this might come in handy.

I am unsure whether `sysfs_input_wakeup` is the right thing to call it, open to suggestions.