### PR TITLE
addrsetup: avoid selinux denials for brcmfmac

### DIFF
--- a/vendor/addrsetup.te
+++ b/vendor/addrsetup.te
@@ -12,3 +12,5 @@ allow addrsetup wifi_vendor_data_file:dir rw_dir_perms;
 allow addrsetup wifi_vendor_data_file:file create_file_perms;
 
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
+
+allow addrsetup self:capability { create net_admin net_raw };


### PR DESCRIPTION
03-09 09:49:18.239   951   951 I macaddrsetup: type=1400 audit(0.0:27): avc: denied { create } for scontext=u:r:addrsetup:s0 tcontext=u:r:addrsetup:s0 tclass=udp_socket permissive=1
03-09 09:49:18.239   951   951 I macaddrsetup: type=1400 audit(0.0:28): avc: denied { net_raw } for capability=13 scontext=u:r:addrsetup:s0 tcontext=u:r:addrsetup:s0 tclass=capability permissive=1
03-09 09:49:18.239   951   951 I macaddrsetup: type=1400 audit(0.0:30): avc: denied { net_admin } for capability=12 scontext=u:r:addrsetup:s0 tcontext=u:r:addrsetup:s0 tclass=capability permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>