### PR TITLE
addrsetup: avoid selinux denials

### DIFF
--- a/vendor/addrsetup.te
+++ b/vendor/addrsetup.te
@@ -14,3 +14,4 @@ allow addrsetup wifi_vendor_data_file:file create_file_perms;
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
 allow addrsetup self:capability { net_admin net_raw };
+allow addrsetup self:udp_socket create;


### PR DESCRIPTION
03-09 09:49:18.239   951   951 I macaddrsetup: type=1400 audit(0.0:27): avc: denied { create } for scontext=u:r:addrsetup:s0 tcontext=u:r:addrsetup:s0 tclass=udp_socket permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>