### PR TITLE
[WIP] PeripheralManager: Re-label as non-vendor type (temporarily), fix denials

### DIFF
--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -6,7 +6,16 @@ init_daemon_domain(per_mgr);
 
 add_service(per_mgr, per_mgr_service)
 
-vndbinder_use(per_mgr)
+# TODO(b/vndswitch): Remove once per_mgr uses vendor binder and
+# per_mgr_service is a vndservice_manager_type
+typeattribute per_mgr binder_in_vendor_violators;
+
+# TODO(b/vndswitch): Enable once per_proxy uses vendor binder
+#vndbinder_use(per_mgr)
+
+# TODO(b/vndswitch): Remove once per_proxy uses vendor binder
+binder_use(per_mgr)
+
 binder_call(per_mgr, hal_gnss)
 binder_call(per_mgr, per_proxy)
 binder_call(per_mgr, rild)

--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -30,3 +30,6 @@ allow per_mgr ssr_device:chr_file { open read };
 r_dir_file(per_mgr, sysfs_msm_subsys)
 r_dir_file(per_mgr, sysfs_esoc)
 allow per_mgr device:dir search;
+
+# TODO: To be decided if necessary
+dontaudit per_mgr kernel:system module_request;

--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -29,3 +29,4 @@ allow per_mgr ssr_device:chr_file { open read };
 
 r_dir_file(per_mgr, sysfs_msm_subsys)
 r_dir_file(per_mgr, sysfs_esoc)
+allow per_mgr device:dir search;

--- a/vendor/per_proxy.te
+++ b/vendor/per_proxy.te
@@ -13,5 +13,8 @@ typeattribute per_proxy binder_in_vendor_violators;
 binder_use(per_proxy)
 
 binder_call(per_proxy, per_mgr)
+
+allow per_proxy per_mgr_service:service_manager find;
+
 r_dir_file(per_proxy, sysfs_msm_subsys)
 r_dir_file(per_proxy, sysfs_esoc)

--- a/vendor/per_proxy.te
+++ b/vendor/per_proxy.te
@@ -4,9 +4,14 @@ type per_proxy_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(per_proxy)
 
-allow per_proxy per_mgr_service:service_manager find;
+# TODO(b/vndswitch): Remove once per_proxy uses vendor binder
+typeattribute per_proxy binder_in_vendor_violators;
 
-vndbinder_use(per_proxy)
+# TODO(b/vndswitch): Enable once per_proxy uses vendor binder
+#vndbinder_use(per_proxy)
+# TODO(b/vndswitch): Remove once per_proxy uses vendor binder
+binder_use(per_proxy)
+
 binder_call(per_proxy, per_mgr)
 r_dir_file(per_proxy, sysfs_msm_subsys)
 r_dir_file(per_proxy, sysfs_esoc)

--- a/vendor/service.te
+++ b/vendor/service.te
@@ -1,1 +1,2 @@
 type timekeep_service, service_manager_type;
+type per_mgr_service, service_manager_type;

--- a/vendor/service_contexts
+++ b/vendor/service_contexts
@@ -1,1 +1,3 @@
 com.sony.timekeep                       u:object_r:timekeep_service:s0
+# TODO(b/vndswitch): Remove once per_mgr uses vendor binder
+vendor.qcom.PeripheralManager           u:object_r:per_mgr_service:s0

--- a/vendor/vndservice.te
+++ b/vendor/vndservice.te
@@ -1,3 +1,4 @@
 type qdisplay_service,             vndservice_manager_type;
-type per_mgr_service,              vndservice_manager_type;
+# TODO(b/vndswitch): Revert once per_mgr uses vndbinder:
+#type per_mgr_service,              vndservice_manager_type;
 type qcrilam_service,              vndservice_manager_type;

--- a/vendor/vndservice_contexts
+++ b/vendor/vndservice_contexts
@@ -1,3 +1,4 @@
 display.qservice                        u:object_r:qdisplay_service:s0
-vendor.qcom.PeripheralManager           u:object_r:per_mgr_service:s0
+# TODO(b/vndswitch): Re-enable once per_mgr uses vendor binder
+#vendor.qcom.PeripheralManager           u:object_r:per_mgr_service:s0
 com.sony.qcrilam                        u:object_r:qcrilam_service:s0


### PR DESCRIPTION
vendor.qcom.PeripheralManager, pm-proxy and pm-service are not yet using vndbinder and their services cannot be accessed as a `vndservice_manager_type`.

Temporarily switch their labels to non-vendor types and change the binder-related labels as well.

 Note: vendor.qcom.PeripheralManager needs to be labeled as a regular `service_manager_type`, else it will not be recognized correctly and instead be assigned `default_android_service`.
