### PR TITLE
Add license, formatting tips

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+Copyright (c) 2016-2017, The Linux Foundation.
+Copyright (c) 2018, Sony Mobile Communications Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,26 @@ Failure to include the above may result in your patch being rejected.
 This sepolicy also requires device specific `file_contexts` and `genfs_contexts`
 that can be found in each platform's git repository.
 
+# License
+See `LICENSE.md`.
+
+# Formatting Tips
+
+**General**
+
+- Group declarations of the same type together
+- When adding file permissions, first the `dir` line, then the `file` line
+- Use macros whenever possible
+  (look for `te_macros`, `global_macros` in `system/sepolicy/public/`)
+
+**Recommended Order**
+
+1. Documentation, if any
+2. `domain`, `mydomain_exec`
+3. `init_daemon_domain` or `app_domain`
+4. `typeattribute` violation declarations
+5. `binder_use()` and equivalents
+6. `binder_call()` and equivalents
+7. `add_service()` and equivalents, `hal_server_domain()`
+7. File permissions
+8. `dontaudit`


### PR DESCRIPTION
3-clause BSD is what most projects use for sepolicy, c.f. [CodeAurora](https://source.codeaurora.org/quic/la/device/qcom/sepolicy/tree/common/hal_perf_default.te?h=LA.UM.6.3.r4-05900-sdm845.0).

Formatting tips help to how to order policy statements.