### PR TITLE
vendor_camera_prop: appdomain access, cleanup

### DIFF
--- a/vendor/appdomain.te
+++ b/vendor/appdomain.te
@@ -1,2 +1,4 @@
 # For the camera app
 get_prop(appdomain, camera_prop)
+# All sorts of domains request this, and granting access should be harmless
+get_prop(appdomain, vendor_camera_prop)

--- a/vendor/cameraserver.te
+++ b/vendor/cameraserver.te
@@ -2,4 +2,3 @@ allow cameraserver gpu_device:chr_file rw_file_perms;
 
 allow cameraserver system_server:unix_stream_socket { read write };
 set_prop(cameraserver, vendor_camera_prop)
-get_prop(cameraserver, vendor_camera_prop)

--- a/vendor/hal_camera_default.te
+++ b/vendor/hal_camera_default.te
@@ -15,9 +15,7 @@ binder_call(hal_camera_default, hal_graphics_allocator)
 binder_call(hal_camera_default, surfaceflinger)
 
 set_prop(hal_camera_default, camera_prop)
-allow hal_camera_default vendor_camera_prop:property_service set;
-
-allow hal_camera_default vendor_camera_prop:file r_file_perms;
+set_prop(hal_camera_default, vendor_camera_prop)
 
 allow hal_camera_default sysfs_camera:dir r_dir_perms;
 allow hal_camera_default sysfs_camera:file r_file_perms;


### PR DESCRIPTION
Macros make our policy more readable. `set_prop` includes `get_prop` already.

All sorts of domains request access to `vendor_camera_prop` and granting read-only access should be harmless.