### PR TITLE
avoid bt-qti denials

### DIFF
--- a/vendor/hal_bluetooth_default.te
+++ b/vendor/hal_bluetooth_default.te
@@ -13,4 +13,5 @@ set_prop(hal_bluetooth_default, vendor_bluetooth_prop)
 
 r_dir_file(hal_bluetooth_default, persist_file)
 r_dir_file(hal_bluetooth_default, vendor_firmware_file)
+r_dir_file(hal_bluetooth_default, mnt_vendor_file)
 r_dir_rw_file(hal_bluetooth_default, sysfs_bluetooth)


### PR DESCRIPTION
following CAF
https://source.codeaurora.org/quic/la/device/qcom/sepolicy/tree/vendor/common/hal_bluetooth_qti.te?h=LA.UM.7.3.r1-06600-sdm845.0#n49

avoid
01-05 00:12:43.409   718   718 I HwBinder:718_1: type=1400 audit(0.0:198): avc: denied { search } for name=vendor dev=tmpfs ino=21530 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:mnt_vendor_file:s0 tclass=dir permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>