### PR TITLE
[1/3] sepolicy.mk: Fix legacy build variable

### DIFF
--- a/sepolicy.mk
+++ b/sepolicy.mk
@@ -2,7 +2,7 @@
 # SELinux policy variable definitions
 LOCAL_SEPOLICY := device/sony/sepolicy
 
-BOARD_SEPOLICY_DIRS += \
+BOARD_VENDOR_SEPOLICY_DIRS += \
     $(LOCAL_SEPOLICY)/vendor
 
 BOARD_PLAT_PUBLIC_SEPOLICY_DIR += \


### PR DESCRIPTION
Rename `BOARD_SEPOLICY_DIRS` to `BOARD_VENDOR_SEPOLICY_DIRS` for the `vendor/` subfolder.

See system/sepolicy/Android.mk:
> BOARD_SEPOLICY_DIRS was used for vendor/odm sepolicy customization before.
> It has been replaced by BOARD_VENDOR_SEPOLICY_DIRS (mandatory) and
> BOARD_ODM_SEPOLICY_DIRS (optional). BOARD_SEPOLICY_DIRS is still allowed for
> backward compatibility, which will be merged into BOARD_VENDOR_SEPOLICY_DIRS.
```
ifdef BOARD_SEPOLICY_DIRS
BOARD_VENDOR_SEPOLICY_DIRS += $(BOARD_SEPOLICY_DIRS)
endif
```
There are, however, [some remnants where `BOARD_SEPOLICY_DIRS` is used explicitly](https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r22/Android.mk#285), and this can mess with rules. So better do it properly here and not get caught by erroneous neverallows. 