### PR TITLE
Timekeep:  Drop fowner cap, search msm_subsys

### DIFF
--- a/vendor/timekeep.te
+++ b/vendor/timekeep.te
@@ -20,3 +20,6 @@ set_prop(timekeep, timekeep_prop)
 # Read /sys/class/rtc/rtc0/since_epoch
 allow timekeep sysfs_rtc:dir search;
 allow timekeep sysfs_rtc:{ file lnk_file } r_file_perms;
+# The open() call in timekeep.c will traverse parent folders
+# of the target path as well to resolve the symlink.
+allow timekeep sysfs_msm_subsys:dir search;

--- a/vendor/timekeep.te
+++ b/vendor/timekeep.te
@@ -8,7 +8,7 @@ type timekeep_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(timekeep)
 
 # Grant permission to set system time and to set the real-time clock
-allow timekeep self:capability { fowner sys_time };
+allow timekeep self:capability sys_time;
 
 # Write to /data/vendor/time/ats_2
 allow timekeep timekeep_vendor_data_file:dir rw_dir_perms;

--- a/vendor/timekeep_app.te
+++ b/vendor/timekeep_app.te
@@ -20,6 +20,7 @@ allow timekeep_app timekeep_vendor_data_file:file create_file_perms;
 # Read /sys/class/rtc/rtc0/since_epoch
 allow timekeep_app sysfs_rtc:dir { search };
 allow timekeep_app sysfs_rtc:{ file lnk_file } r_file_perms;
+allow timekeep sysfs_msm_subsys:dir search;
 
 # Set the persist.sys.timeadjust property
 set_prop(timekeep_app, timekeep_prop)


### PR DESCRIPTION
`timekeep.c` never dropped root privileges, so `{fowner}` was wrong.  
Now the program runs outfitted with `CAP_SYS_TIME` via `init.rc` and only needs `{sys_time}` caps in sepolicy.

The `open()` call in` timekeep.c` will traverse parent folders of the target path as well to resolve the `rtc` symlink. (It points from e.g. `/sys/class/rtc/rtc0/since_epoch` to `/sys/device/platform/[...]/rtc/rtc0/since_epoch`)
Same goes for the Java app.