### PR TITLE
Label new health HAL and add permissions

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -39,6 +39,7 @@ type ims_socket, file_type;
 type vendor_firmware_file, file_type, vendor_file_type, contextmount_type;
 
 type persist_file, file_type, vendor_persist_type;
+type persist_battery_file, file_type, vendor_persist_type;
 type persist_data_file, file_type, vendor_persist_type;
 type persist_display_file, file_type, vendor_persist_type;
 type persist_drm_file, file_type, vendor_persist_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -90,6 +90,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@1\.1-service-qti                      u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.1-service\.clearkey                 u:object_r:hal_drm_clearkey_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.health@2\.0-service\.sony                  u:object_r:hal_health_default_exec:s0
 
 # sysfs paths
 # ToF sensor for CASH

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -186,6 +186,7 @@
 
 # /persist
 /mnt/vendor/persist(/.*)?            u:object_r:persist_file:s0
+/mnt/vendor/persist/battery(/.*)?    u:object_r:persist_battery_file:s0
 /mnt/vendor/persist/data(/.*)?       u:object_r:persist_data_file:s0
 /mnt/vendor/persist/display(/.*)?    u:object_r:persist_display_file:s0
 /mnt/vendor/persist/drm(/.*)?        u:object_r:persist_drm_file:s0

--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -1,0 +1,12 @@
+# Custom Sony health HAL
+
+# Register timerfd to periodically check (battery) health
+allow hal_health_default self:capability2 wake_alarm;
+
+# Write battery cycles and capacity to /{mnt/vendor/}persist/battery/
+allow hal_health_default persist_battery_file:dir rw_dir_perms;
+allow hal_health_default persist_battery_file:file create_file_perms;
+# Resolve the underlying path of /sys/class/power_supply/battery/
+# and traverse /persist/ paths
+allow hal_health_default { sysfs_msm_subsys persist_file }:dir search;
+allow hal_health_default sysfs_batteryinfo:file r_file_perms;

--- a/vendor/healthd.te
+++ b/vendor/healthd.te
@@ -1,3 +1,5 @@
+# TODO(b/healthd_deprecation): Remove healthd policy
+# and replace with hal_health_default once migration is complete
 allow healthd self:capability2 wake_alarm;
 allow healthd sysfs_batteryinfo:file r_file_perms;
 allow healthd sysfs_usb_supply:file r_file_perms;


### PR DESCRIPTION
Since `android.hardware.health@2.0-service.sony` replaces `healthd` and the AOSP policy is barebones, add the needed permissions for our new HAL.

Permissions are a small subset of what Pixel HALs use.

Label `/mnt/vendor/persist/battery/` folder:  
Naming follows crosshatch sepolicy, except we mount `/persist/` under `/mnt/vendor/persist/`.