### PR TITLE
Remove unused timekeep_service label

### DIFF
--- a/vendor/service.te
+++ b/vendor/service.te
@@ -1,1 +1,0 @@
-type timekeep_service, service_manager_type;

--- a/vendor/service_contexts
+++ b/vendor/service_contexts
@@ -1,1 +1,0 @@
-com.sony.timekeep                       u:object_r:timekeep_service:s0


### PR DESCRIPTION
The com.sony.TimeKeep Java app never starts any kind of service, it only receives broadcasts.

The label was never used and can thus be removed from sepolicy.