### PR TITLE
vendor_init: Allow creating /persist/battery/

### DIFF
--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -24,5 +24,7 @@ allow vendor_init proc_irq:file write;
 allow vendor_init proc_kernel_printk:file write;
 
 allow vendor_init persist_file:lnk_file read;
+# Create and chown /(mnt/vendor/)persist/battery/ folder for health HAL
+allow vendor_init persist_battery_file:dir create_dir_perms;
 
 allow vendor_init device:file { create write };


### PR DESCRIPTION
This is needed for the .rc file shipped with the new health HAL.

vendor_init needs permissions to create and chown the /(mnt/vendor/)persist/battery/ folder

Fix the following denial:

- vendor_init:
  avc: granted { setattr } for name="battery" dev="mmcblk0p44" ino=48 \
    scontext=u:r:vendor_init:s0 tcontext=u:object_r:persist_battery_file:s0 tclass=dir