### PR TITLE
wcnss: Remove unused permissions

### DIFF
--- a/vendor/wcnss_service.te
+++ b/vendor/wcnss_service.te
@@ -25,11 +25,6 @@ allow wcnss_service self:netlink_socket create_socket_perms_no_ioctl;
 allow wcnss_service vendor_firmware_file:file { read open getattr };
 allow wcnss_service vendor_firmware_file:dir search;
 
-allow wcnss_service hostapd_data_file:dir rw_dir_perms;
-allow wcnss_service hostapd_data_file:file create_file_perms;
-allow wcnss_service wpa_data_file:dir rw_dir_perms;
-allow wcnss_service wpa_data_file:file create_file_perms;
-
 r_dir_file(wcnss_service, sysfs_msm_subsys)
 
 allow wcnss_service sysfs_soc:dir search;


### PR DESCRIPTION
Permissions for /data/vendor/wifi/{hostapd,wpa}/* were granted in 3b87ba2d18eb88892ef9300cfd8243b520361442 "/data/vendor/wifi/*: Switch to default AOSP labels"

But they were never used, wcnss only wants to read /data/vendor/wifi/wlan.bin.

(@alviteri please confirm)