### PR TITLE
Avoid wifi denials

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -62,6 +62,7 @@ type bluetooth_vendor_data_file, file_type, data_file_type;
 type audio_vendor_data_file, file_type, data_file_type;
 type camera_vendor_data_file, file_type, data_file_type;
 type ipa_vendor_data_file, file_type, data_file_type;
+type wifi_vendor_data_file, file_type, data_file_type;
 
 # diag sysfs files
 type sysfs_diag, fs_type, sysfs_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -173,6 +173,7 @@
 /data/vendor/audio(/.*)?               u:object_r:audio_vendor_data_file:s0
 /data/vendor/camera(/.*)?              u:object_r:camera_vendor_data_file:s0
 /data/vendor/ipa(/.*)?                 u:object_r:ipa_vendor_data_file:s0
+/data/vendor/wifi(/.*)?                u:object_r:wifi_vendor_data_file:s0
 
 # TODO: Remove them once no need to maintain the backward compatibility. (b/111219177)
 /persist                             u:object_r:rootfs:s0

--- a/vendor/hal_wifi_supplicant_default.te
+++ b/vendor/hal_wifi_supplicant_default.te
@@ -1,2 +1,2 @@
 allow hal_wifi_supplicant_default proc_net:file w_file_perms;
-allow hal_wifi_supplicant_default vendor_data_file:dir search;
+allow hal_wifi_supplicant_default wifi_vendor_data_file:dir search;

--- a/vendor/ueventd.te
+++ b/vendor/ueventd.te
@@ -1,5 +1,8 @@
+typeattribute ueventd data_between_core_and_vendor_violators;
+
 r_dir_file(ueventd, vendor_firmware_file)
 r_dir_file(ueventd, persist_file)
+r_dir_file(ueventd, wifi_vendor_data_file)
 
 allow ueventd {
     { sysfs_type - usermodehelper }

--- a/vendor/wcnss_service.te
+++ b/vendor/wcnss_service.te
@@ -31,6 +31,7 @@ allow wcnss_service wpa_data_file:dir rw_dir_perms;
 allow wcnss_service wpa_data_file:file create_file_perms;
 
 r_dir_file(wcnss_service, sysfs_msm_subsys)
+r_dir_file(wcnss_service, wifi_vendor_data_file)
 
 allow wcnss_service sysfs_soc:dir search;
 allow wcnss_service sysfs_soc:file r_file_perms;


### PR DESCRIPTION
A change to #431 that compiles with FULL_TREBLE.

avc: denied { read } for name=wlan_mac.bin dev=sda73 ino=784934 \
  scontext=u:r:ueventd:s0 tcontext=u:object_r:vendor_data_file:s0 tclass=file
avc: denied { open } for path=/data/vendor/wifi/wlan_mac.bin dev=sda73 \
  ino=784934 scontext=u:r:ueventd:s0 tcontext=u:object_r:vendor_data_file:s0 tclass=file
avc: denied { getattr } for path=/data/vendor/wifi/wlan_mac.bin dev=sda73 \
  ino=784934 scontext=u:r:ueventd:s0 tcontext=u:object_r:vendor_data_file:s0 tclass=file
avc: denied { search } for name="wifi" dev="sda73" ino=784902 scontext=u:r:wcnss_service:s0 \
  tcontext=u:object_r:wifi_vendor_data_file:s0 tclass=dir
avc: denied { search } for name="wifi" dev="sda73" ino=784902 scontext=u:r:hal_wifi_supplicant_default:s0 \
  tcontext=u:object_r:wifi_vendor_data_file:s0 tclass=dir

Following CAF LA.UM.7.3.r1-06600-sdm845.0