### PR TITLE
avoid health denials

### DIFF
--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -8,7 +8,10 @@ allow hal_health_default mnt_vendor_file:dir search;
 # Write battery cycles and capacity to /{mnt/vendor/}persist/battery/
 allow hal_health_default persist_battery_file:dir rw_dir_perms;
 allow hal_health_default persist_battery_file:file create_file_perms;
+
 # Resolve the underlying path of /sys/class/power_supply/battery/
 # and traverse /persist/ paths
-allow hal_health_default { sysfs_msm_subsys persist_file }:dir search;
+allow hal_health_default persist_file:dir search;
 allow hal_health_default sysfs_batteryinfo:file r_file_perms;
+
+r_dir_file(hal_health_default, sysfs_msm_subsys)


### PR DESCRIPTION
10-17 22:05:21.969   723   723 W android.hardwar: type=1400 audit(0.0:4): avc: denied { read } for name=type dev=sysfs ino=57470 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_msm_subsys:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>