### PR TITLE
PeripheralManager: Re-label as non-vendor type [LITE]

### DIFF
--- a/private/service_contexts
+++ b/private/service_contexts
@@ -1,0 +1,7 @@
+# TODO(b/vndswitch): Remove this once per_mgr uses vendor binder.
+# vendor.qcom.PeripheralManager needs to be defined here
+# in the "private"(=platform) policy, since it is currently regognozed
+# as a regular platform/framework service and will thus be ignored
+# when defined in vendor/{vnd,}service_contexts
+vendor.qcom.PeripheralManager           u:object_r:per_mgr_service:s0
+

--- a/public/service.te
+++ b/public/service.te
@@ -1,0 +1,3 @@
+# TODO(b/vndswitch): Move this declaration to
+# vendor/vndservice.te once per_proxy uses vendor binder
+type per_mgr_service,              service_manager_type;

--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -4,13 +4,26 @@ type per_mgr_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(per_mgr);
 
-add_service(per_mgr, per_mgr_service)
+# TODO(b/vndswitch): Remove once per_mgr uses vendor binder and
+# per_mgr_service is a vndservice_manager_type
+not_full_treble(`
+  typeattribute per_mgr binder_in_vendor_violators;
+')
 
 vndbinder_use(per_mgr)
+# TODO(b/vndswitch): Remove once per_proxy uses vendor binder
+not_full_treble(`
+  binder_use(per_mgr)
+')
+
 binder_call(per_mgr, hal_gnss)
 binder_call(per_mgr, per_proxy)
 binder_call(per_mgr, rild)
 binder_call(per_mgr, wcnss_service)
+
+not_full_treble(`
+  add_service(per_mgr, per_mgr_service)
+')
 
 allow per_mgr self:capability net_bind_service;
 

--- a/vendor/per_proxy.te
+++ b/vendor/per_proxy.te
@@ -4,9 +4,22 @@ type per_proxy_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(per_proxy)
 
-allow per_proxy per_mgr_service:service_manager find;
+# TODO(b/vndswitch): Remove once per_proxy uses vendor binder
+not_full_treble(`
+  typeattribute per_proxy binder_in_vendor_violators;
+')
 
 vndbinder_use(per_proxy)
+# TODO(b/vndswitch): Remove once per_proxy uses vendor binder
+not_full_treble(`
+  binder_use(per_proxy)
+')
+
 binder_call(per_proxy, per_mgr)
+
+not_full_treble(`
+  allow per_proxy per_mgr_service:service_manager find;
+')
+
 r_dir_file(per_proxy, sysfs_msm_subsys)
 r_dir_file(per_proxy, sysfs_esoc)

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -1,9 +1,21 @@
+# TODO(b/vndswitch): Remove once per_mgr uses vendor binder and
+# per_mgr_service is a vndservice_manager_type
+not_full_treble(`
+  typeattribute rild binder_in_vendor_violators;
+')
+
 vndbinder_use(rild)
+# TODO(b/vndswitch): Remove once per_mgr uses vendor binder
+not_full_treble(`
+  binder_use(rild)
+')
 
 binder_call(rild, per_mgr)
 binder_call(rild, qcrilam_app);
 
-allow rild per_mgr_service:service_manager find;
+not_full_treble(`
+  allow rild per_mgr_service:service_manager find;
+')
 
 allow rild radio_vendor_data_file:dir create_dir_perms;
 allow rild radio_vendor_data_file:file create_file_perms;

--- a/vendor/vndservice.te
+++ b/vendor/vndservice.te
@@ -1,3 +1,5 @@
 type qdisplay_service,             vndservice_manager_type;
-type per_mgr_service,              vndservice_manager_type;
+# TODO(b/vndswitch): Re-enable once per_mgr uses vndbinder,
+# then also remove the label from private/service_contexts
+#type per_mgr_service,              vndservice_manager_type;
 type qcrilam_service,              vndservice_manager_type;

--- a/vendor/vndservice_contexts
+++ b/vendor/vndservice_contexts
@@ -1,3 +1,4 @@
 display.qservice                        u:object_r:qdisplay_service:s0
-vendor.qcom.PeripheralManager           u:object_r:per_mgr_service:s0
+# TODO(b/vndswitch): Re-enable this once per_mgr uses vendor binder
+#vendor.qcom.PeripheralManager           u:object_r:per_mgr_service:s0
 com.sony.qcrilam                        u:object_r:qcrilam_service:s0

--- a/vendor/wcnss_service.te
+++ b/vendor/wcnss_service.te
@@ -5,10 +5,18 @@ type wcnss_service_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(wcnss_service)
 net_domain(wcnss_service)
 
+# TODO(b/vndswitch): Remove once per_mgr uses vendor binder and
+# per_mgr_service is a vndservice_manager_type
+not_full_treble(`
+  typeattribute wcnss_service binder_in_vendor_violators;
+')
+
 vndbinder_use(wcnss_service)
 binder_call(wcnss_service, per_mgr)
 
-allow wcnss_service per_mgr_service:service_manager find;
+not_full_treble(`
+  allow wcnss_service per_mgr_service:service_manager find;
+')
 allow wcnss_service proc_net:file rw_file_perms;
 
 allow wcnss_service self:capability {


### PR DESCRIPTION
vendor.qcom.PeripheralManager, pm-proxy and pm-service are not yet using vndbinder and thus do not get picked up as vndservices.

Since PeripheralManager thus is a regular platform service in Android's eyes, its policy needs to be defined in the "private"(=platform) policy.  Any label assigned to it in vndservice_contexts will be ignored and vendor.qcom.PeripheralManager will thus be labeled according to a wildcard as default_android_service.

Because of the split sepolicy for full-treble devices (meaning the policy no longer resides in rootfs of boot.img as {vendor,plat}_service_contexts and the "sepolicy" binary representation also moves into two parts inside /{system,vendor}/etc/sepolicy/), platform/framework and vendor can no longer share access to a "service_manager_type" definition in vendor/service.te, meaning the definition needs to be moved into public/service.te, from where it will be baked into both of the resulting platform and vendor policy.cil files at build time.

This commit temporarily switches the labels to non-vendor types. The policy should stay buildable on both Oreo and Pie+, with any combination of "{PRODUCT,BOARD}", "SPLIT" and  FULL_TREBLE_OVERRIDE" build variables set.

Let's try to get rid of that as soon as possible.
Once the migration to vndbinder is complete, fix the b/vndswitch TODOs.