### PR TITLE
tee: Update label for listener prop

### DIFF
--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -5,6 +5,7 @@ sys.keymaster.loaded       u:object_r:keymaster_prop:s0
 net.r_rmnet_data0          u:object_r:net_rmnet_prop:s0
 persist.net.doxlat         u:object_r:net_radio_prop:s0
 sys.listeners.registered   u:object_r:tee_listener_prop:s0
+vendor.sys.listeners.      u:object_r:tee_listener_prop:s0
 wc_transport.              u:object_r:wc_prop:s0
 persist.sys.timeadjust     u:object_r:timekeep_prop:s0
 adb.network.port.es        u:object_r:adbtcpes_prop:s0


### PR DESCRIPTION
The property has been renamed from `sys.listeners.registered` to `vendor.sys.listeners.registered`.
Leave the old prop in until the migration is complete.

avc:  denied  { set } for property=vendor.sys.listeners.registered pid=489 \
  uid=1000 gid=1000 scontext=u:r:tee:s0 tcontext=u:object_r:vendor_default_prop:s0 tclass=property_service