### PR TITLE
[DONOTMERGE] drm-widevine: Read mediadrm files

### DIFF
--- a/vendor/hal_drm_widevine.te
+++ b/vendor/hal_drm_widevine.te
@@ -1,0 +1,2 @@
+# Access /data/mediadrm/* and /data/misc/media/*
+r_dir_file(hal_drm_widevine, media_data_file)


### PR DESCRIPTION
Widevine wants access to /data/mediadrm/ and /data/misc/media/

avc: denied { search } for name="mediadrm" dev="dm-0" ino=252961 \
  scontext=u:r:hal_drm_widevine:s0 tcontext=u:object_r:media_data_file:s0 tclass=dir
avc: denied { read } for name="IDM1013" dev="dm-0" ino=252962 \
  scontext=u:r:hal_drm_widevine:s0 tcontext=u:object_r:media_data_file:s0 tclass=dir
WVCdm   : L3 Initialized. Trying L1.
WVCdm   : Could not load liboemcrypto.so. Falling back to L3.  dlopen failed: library "liboemcrypto.so" not found
WVCdm   : L3 Terminate.
WVCdm   : CdmEngine::OpenSession
WVCdm   : Level3 Library 4445 Oct  4 2017 17:06:25
WVCdm   : L3 Initialized. Trying L1.
WVCdm   : Could not load liboemcrypto.so. Falling back to L3.  dlopen failed: library "liboemcrypto.so" not found
WVCdm   : CryptoSession::Open: Lock: requested_security_level: Default