### PR TITLE
[WIP] Sensors: Reduce permissions

### DIFF
--- a/vendor/hal_sensors_default.te
+++ b/vendor/hal_sensors_default.te
@@ -11,3 +11,4 @@ allow hal_sensors_default persist_file:dir search;
 allow hal_sensors_default persist_sensors_file:dir create_dir_perms;
 allow hal_sensors_default persist_sensors_file:file create_file_perms;
 
+dontaudit hal_sensors_default kernel:system module_request;

--- a/vendor/sensors.te
+++ b/vendor/sensors.te
@@ -18,8 +18,7 @@ allow sensors persist_file:dir { getattr search };
 allow sensors sensors_vendor_data_file:dir create_dir_perms;
 allow sensors sensors_vendor_data_file:file create_file_perms;
 
-allow sensors system_file:dir r_dir_perms;
-allow sensors sensors_device:chr_file rw_file_perms;
+allow sensors sensors_device:chr_file r_file_perms;
 
 r_dir_file(sensors, sysfs_msm_subsys)
 r_dir_file(sensors, sysfs_soc)


### PR DESCRIPTION
Tested on tone/kagura, please also check on other platforms if this can safely be merged.

`sensors`: Access to sysfs has been specified in more granularity in previous commits, now lock it down.
Read-only access to chr_device is sufficient.

`hal_sensors_default`: dontaudit module_request. The dontaudit for module_request is in accordance with crosshatch sepolicy:
https://android.googlesource.com/device/google/crosshatch-sepolicy/+/android-9.0.0_r30/vendor/qcom/common/hal_sensors_default.te#22
