### PR TITLE
[WIP] per_mgr: Search, dontaudit module_request

### DIFF
--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -30,6 +30,7 @@ allow per_mgr self:capability net_bind_service;
 allow per_mgr self:socket create_socket_perms;
 allowxperm per_mgr self:socket ioctl msm_sock_ipc_ioctls;
 allow per_mgr ssr_device:chr_file { open read };
+allow per_mgr device:dir search;
 
 r_dir_file(per_mgr, sysfs_msm_subsys)
 r_dir_file(per_mgr, sysfs_esoc)

--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -34,3 +34,5 @@ allow per_mgr device:dir search;
 
 r_dir_file(per_mgr, sysfs_msm_subsys)
 r_dir_file(per_mgr, sysfs_esoc)
+
+dontaudit per_mgr kernel:system module_request;


### PR DESCRIPTION
dontaudit module_request: Follow crosshatch sepolicy and ignore:
https://android.googlesource.com/device/google/crosshatch-sepolicy/+/android-9.0.0_r30/vendor/qcom/common/per_mgr.te#26
Denial:
avc: denied { module_request } for comm="pm-service" kmod="net-pf-42" scontext=u:r:per_mgr:s0 tcontext=u:r:kernel:s0 tclass=system

Allow searching for devices
Denial:
avc: denied { search } for comm="pm-service" name="/" dev="tmpfs" \
  ino=13798 scontext=u:r:per_mgr:s0 tcontext=u:object_r:device:s0 tclass=dir