### PR TITLE
dnsmasq: Allow access to netd (b/77868789)

### DIFF
--- a/private/dnsmasq.te
+++ b/private/dnsmasq.te
@@ -1,0 +1,4 @@
+# TODO(b/77868789): Android bug to work around
+# Happens while tethering
+allow dnsmasq netd:fifo_file getattr;
+allow dnsmasq netd:unix_stream_socket getattr;


### PR DESCRIPTION
Happens while tethering.
This is an android bug we have to work around.

avc: denied { getattr } for comm="dnsmasq" path="pipe:[19380]"
  dev="pipefs" ino=19380 scontext=u:r:dnsmasq:s0 tcontext=u:r:netd:s0 tclass=fifo_file permissive=1 b/77868789
avc: denied { getattr } for path="pipe:[19380]"
  dev="pipefs" ino=19380 scontext=u:r:dnsmasq:s0 tcontext=u:r:netd:s0 tclass=fifo_file permissive=1 b/77868789
avc: denied { getattr } for comm="dnsmasq" path="socket:[19388]"
  dev="sockfs" ino=19388 scontext=u:r:dnsmasq:s0 tcontext=u:r:netd:s0 tclass=unix_stream_socket permissive=1 b/77868789
avc: denied { getattr } for path="socket:[19388]"
  dev="sockfs" ino=19388 scontext=u:r:dnsmasq:s0 tcontext=u:r:netd:s0 tclass=unix_stream_socket permissive=1 b/77868789