### PR TITLE
label sys/devices/dsi_panel_driver/pcc_profile as sysfs_pcc_profile

### DIFF
--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -16,6 +16,7 @@ genfscon sysfs /class/devfreq                         u:object_r:sysfs_msm_subsy
 genfscon sysfs /devices/soc/soc:qcom,memlat-cpu0      u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/soc/soc:qcom,memlat-cpu4      u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/mdss_dsi_panel/pcc_profile    u:object_r:sysfs_pcc_profile:s0
+genfscon sysfs /devices/dsi_panel_driver/pcc_profile  u:object_r:sysfs_pcc_profile:s0
 genfscon sysfs /devices/virtual/smdpkt                u:object_r:sysfs_msm_subsys:s0
 
 genfscon sysfs /devices/platform/soc/soc:qcom,cpubw                     u:object_r:sysfs_msm_subsys:s0


### PR DESCRIPTION
avoid

01-23 23:46:19.699  5439  5439 W xtendedsettings: type=1400 audit(0.0:190): avc: denied { write } for name=pcc_profile dev=sysfs ino=51797 scontext=u:r:system_app:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>