### PR TITLE
avoid system_app denials

### DIFF
--- a/vendor/system_app.te
+++ b/vendor/system_app.te
@@ -14,6 +14,7 @@ set_prop(system_app, timekeep_prop)
 # For android setttings
 binder_call(system_app, per_mgr)
 binder_call(system_app, wificond)
+binder_call(system_app, update_engine)
 
 # This is a neverallow anyways, so ignore it
 dontaudit system_app perfprofd:binder call;


### PR DESCRIPTION
01-23 23:46:31.749  1512  1512 W com.android.settings: type=1400 audit(0.0:198): avc: denied { call } for comm=4173796E635461736B202333 scontext=u:r:system_app:s0 tcontext=u:r:update_engine:s0 tclass=binder permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>