### PR TITLE
avoid bt denials

### DIFF
--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -21,3 +21,4 @@ vendor.usb.config          u:object_r:vendor_usb_config_prop:s0
 persist.vendor.usb.config  u:object_r:vendor_usb_config_prop:s0
 vendor.qcom.devup          u:object_r:vendor_device_prop:s0
 ro.vendor.bt.              u:object_r:vendor_bluetooth_prop:s0
+persist.vendor.bt.         u:object_r:vendor_bluetooth_prop:s0


### PR DESCRIPTION
[   33.416196] selinux: avc:  denied  { set } for property=persist.vendor.bt.soc.scram_freqs pid=698 uid=1002 gid=1002 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:vendor_default_prop:s0 tclass=property_service permissive=0\x0a

Signed-off-by: David Viteri <davidteri91@gmail.com>