### PR TITLE
file_contexts: Update vulkan lib path

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -132,6 +132,7 @@
 
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.msm89(52|96|98)\.so   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sdm(660|845)\.so      u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.qcom\.so              u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libEGL_adreno\.so         u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libGLESv1_CM_adreno\.so   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libGLESv2_adreno\.so      u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
For vendor v5, the file was renamed from `vulkan.$platform.so` to `vulkan.qcom.so`