### PR TITLE
wcnss_service: Allow platform binder in non-treble

### DIFF
--- a/vendor/wcnss_service.te
+++ b/vendor/wcnss_service.te
@@ -12,6 +12,11 @@ not_full_treble(`
 ')
 
 vndbinder_use(wcnss_service)
+# TODO(b/vndswitch): Remove once per_mgr uses vendor binder
+not_full_treble(`
+  binder_use(wcnss_service)
+')
+
 binder_call(wcnss_service, per_mgr)
 
 not_full_treble(`


### PR DESCRIPTION
Should be removed along with #446 / 03f39079fa25c3aa3630f502a3403baf2c14d3b1 when PeripheralManager is eventually fixed.

Denial(on apollo):
`avc: denied { call } for scontext=u:r:wcnss_service:s0  tcontext=u:r:servicemanager:s0 tclass=binder`