### PR TITLE
[WIP] cash changes for reading/writing calibration

### DIFF
--- a/vendor/cashsvr.te
+++ b/vendor/cashsvr.te
@@ -26,4 +26,5 @@ dontaudit cashsvr sysfs_msm_subsys:file r_file_perms;
 dontaudit cashsvr sysfs:dir r_dir_perms;
 dontaudit cashsvr sysfs:file r_file_perms;
 
+# Set camera props, read persist.cash.*
 set_prop(cashsvr, vendor_camera_prop)

--- a/vendor/cashsvr.te
+++ b/vendor/cashsvr.te
@@ -9,14 +9,22 @@ init_daemon_domain(cashsvr)
 # For dropping permissions
 allow cashsvr self:capability { chown setuid };
 
+# Connect to the tad daemon by using libta.so
+unix_socket_connect(cashsvr, tad, tad)
+
 allow cashsvr cashsvr_socket:dir rw_dir_perms;
 allow cashsvr cashsvr_socket:sock_file create_file_perms;
+
+# Write calibrations to /data/vendor/cashsvr/
+rw_dir_file(cashsvr, cashsvr_vendor_data_file)
+allow cashsvr cashsvr_vendor_data_file:file create_file_perms;
 
 allow cashsvr input_device:dir search;
 allow cashsvr input_device:chr_file r_file_perms;
 
 allow cashsvr sysfs_input_name:file r_file_perms;
 allow cashsvr sysfs_input_control:file { rw_file_perms setattr };
+
 allow cashsvr sysfs_tof_sensor:file { rw_file_perms setattr };
 allow cashsvr sysfs_rgbc_sensor:file { rw_file_perms setattr };
 

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -28,6 +28,7 @@ type debugfs_mdp, debugfs_type, fs_type;
 type debugfs_icnss, debugfs_type, fs_type;
 
 type location_vendor_data_file, file_type, data_file_type;
+type cashsvr_vendor_data_file, file_type, data_file_type;
 
 type qmuxd_socket, file_type;
 type netmgrd_socket, file_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -104,6 +104,8 @@
 # ToF sensor for CASH
 /sys/devices/virtual/input/input[0-9]+/enable_ps_sensor                                      u:object_r:sysfs_tof_sensor:s0
 /sys/devices/virtual/input/input[0-9]+/set_use_case                                          u:object_r:sysfs_tof_sensor:s0
+/sys/devices/virtual/input/input[0-9]+/set_ref_spads                                         u:object_r:sysfs_tof_sensor:s0
+/sys/devices/virtual/input/input[0-9]+/set_um_offset                                         u:object_r:sysfs_tof_sensor:s0
 # RGBCIR sensor for CASH
 /sys/devices/virtual/input/input[0-9]+/als_(.*)+                                             u:object_r:sysfs_rgbc_sensor:s0
 # Real-time-clock

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -158,16 +158,17 @@
 /(system/vendor|vendor|odm)/lib(64)?/libaptXHD_encoder\.so            u:object_r:same_process_hal_file:s0
 
 # data files
-/data/vendor/radio(/.*)?               u:object_r:radio_vendor_data_file:s0
-/data/vendor/sensors(/.*)?             u:object_r:sensors_vendor_data_file:s0
-/data/vendor/netmgr(/.*)?              u:object_r:netmgr_vendor_data_file:s0
-/data/vendor/nfc(/.*)?                 u:object_r:nfc_vendor_data_file:s0
-/data/vendor/time(/.*)?                u:object_r:timekeep_vendor_data_file:s0
-/data/vendor/location(/.*)?            u:object_r:location_vendor_data_file:s0
-/data/vendor/bluetooth(/.*)?           u:object_r:bluetooth_vendor_data_file:s0
 /data/vendor/audio(/.*)?               u:object_r:audio_vendor_data_file:s0
+/data/vendor/bluetooth(/.*)?           u:object_r:bluetooth_vendor_data_file:s0
+/data/vendor/cashsvr(/.*)?             u:object_r:cashsvr_vendor_data_file:s0
 /data/vendor/camera(/.*)?              u:object_r:camera_vendor_data_file:s0
 /data/vendor/ipa(/.*)?                 u:object_r:ipa_vendor_data_file:s0
+/data/vendor/location(/.*)?            u:object_r:location_vendor_data_file:s0
+/data/vendor/netmgr(/.*)?              u:object_r:netmgr_vendor_data_file:s0
+/data/vendor/nfc(/.*)?                 u:object_r:nfc_vendor_data_file:s0
+/data/vendor/radio(/.*)?               u:object_r:radio_vendor_data_file:s0
+/data/vendor/sensors(/.*)?             u:object_r:sensors_vendor_data_file:s0
+/data/vendor/time(/.*)?                u:object_r:timekeep_vendor_data_file:s0
 /data/vendor/wifi(/.*)?                u:object_r:wifi_vendor_data_file:s0
 
 # TODO: Remove them once no need to maintain the backward compatibility. (b/111219177)


### PR DESCRIPTION
- Add label for cashsvr data folder
- Reorder the data folders alphabetically as well
- Save calibration from Misc-TA to data dir
  Changes brought by: sonyxperiadev/vendor-sony-oss-cash#11:
  cashsvr communicates over sockets with the tad daemon to get calibration data from the Misc-TA partition.
  It then saves that calibration data to `/data/vendor/cashsvr/*` and reads it at successive startups.
- cashsvr: Label ToF/SPAD sysfs nodes: This is needed to set ToF and RGBC-IR calibrations from userspace