### PR TITLE
avoid health denials

### DIFF
--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -11,4 +11,4 @@ allow hal_health_default persist_battery_file:file create_file_perms;
 # Resolve the underlying path of /sys/class/power_supply/battery/
 # and traverse /persist/ paths
 allow hal_health_default { sysfs_msm_subsys persist_file }:dir search;
-allow hal_health_default sysfs_batteryinfo:file r_file_perms;
+allow hal_health_default { sysfs_batteryinfo sysfs_usb_supply }:file r_file_perms;


### PR DESCRIPTION
5-19 20:30:20.697   651   651 I android.hardwar: type=1400 audit(0.0:7): avc: denied { read } for name=type dev=sysfs ino=39407 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=file permissive=1
05-19 20:30:20.697   651   651 I android.hardwar: type=1400 audit(0.0:8): avc: denied { open } for path=/sys/devices/platform/soc/c176000.i2c/i2c-2/2-001d/power_supply/parallel/type dev=sysfs ino=39407 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=file permissive=1
05-19 20:30:20.697   651   651 I android.hardwar: type=1400 audit(0.0:9): avc: denied { getattr } for path=/sys/devices/platform/soc/c176000.i2c/i2c-2/2-001d/power_supply/parallel/type dev=sysfs ino=39407 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_usb_supply:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>