### PR TITLE
health: Allow restoring battery stats

### DIFF
--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -11,4 +11,6 @@ allow hal_health_default persist_battery_file:file create_file_perms;
 # Resolve the underlying path of /sys/class/power_supply/battery/
 # and traverse /persist/ paths
 allow hal_health_default { sysfs_msm_subsys persist_file }:dir search;
-allow hal_health_default { sysfs_batteryinfo sysfs_usb_supply }:file r_file_perms;
+allow hal_health_default sysfs_usb_supply:file r_file_perms;
+# Read or restore battery statistics
+allow hal_health_default sysfs_batteryinfo:file rw_file_perms;


### PR DESCRIPTION
For restoring `charge_full` and `cycle_count`, write access is also needed.

Denial:
`avc: denied { write } for name="charge_full" dev="sysfs" ino=42624 scontext=u:r:hal_health_default:s0 tcontext=u:object_r:sysfs_batteryinfo:s0 tclass=file`