### PR TITLE
Remove healthd fully

### DIFF
--- a/vendor/healthd.te
+++ b/vendor/healthd.te
@@ -1,6 +1,0 @@
-# TODO(b/healthd_deprecation): Remove healthd policy
-# and replace with hal_health_default once migration is complete
-allow healthd self:capability2 wake_alarm;
-allow healthd sysfs_batteryinfo:file r_file_perms;
-allow healthd sysfs_usb_supply:file r_file_perms;
-allow healthd sysfs_msm_subsys:file { getattr open read };


### PR DESCRIPTION
The new health HAL has been merged almost a month ago and downstream projects should've had enough time to pull the change.