### PR TITLE
sensors: Search /data dir

### DIFF
--- a/vendor/sensors.te
+++ b/vendor/sensors.te
@@ -15,6 +15,9 @@ allow sensors persist_sensors_file:dir rw_dir_perms;
 allow sensors persist_sensors_file:file create_file_perms;
 allow sensors persist_file:dir { getattr search };
 
+# Search /data
+allow sensors system_data_file:dir getattr;
+# Read/write /data/vendor/sensors/*
 allow sensors sensors_vendor_data_file:dir create_dir_perms;
 allow sensors sensors_vendor_data_file:file create_file_perms;
 


### PR DESCRIPTION
Beware: Anything apart from `{getattrr search}` on `system_data_file` is a neverallow!

Denial:
`avc: granted { getattr } for path="/data" dev="mmcblk0p54" ino=2  scontext=u:r:sensors:s0 tcontext=u:object_r:system_data_file:s0 tclass=dir`