### PR TITLE
Label /sys/class/thermal and allow app access

### DIFF
--- a/vendor/appdomain.te
+++ b/vendor/appdomain.te
@@ -2,3 +2,6 @@
 get_prop(appdomain, camera_prop)
 # All sorts of domains request this, and granting access should be harmless
 get_prop(appdomain, vendor_camera_prop)
+# Allow diagnostics apps to read thermals
+allow appdomain sysfs_thermal:dir { search read open };
+allow appdomain sysfs_thermal:file { getattr read open };

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -32,6 +32,7 @@ genfscon sysfs /devices/soc/soc:qcom,kgsl-hyp                           u:object
 genfscon sysfs /devices/soc/soc:qcom,ipa_fws@1e08000                    u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/virtual/rotator/mdss_rotator                    u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/soc/0.qcom,rmtfs_sharedmem                      u:object_r:sysfs_rmtfs:s0
+genfscon sysfs /class/thermal                                           u:object_r:sysfs_thermal:s0
 genfscon sysfs /devices/virtual/thermal                                 u:object_r:sysfs_thermal:s0
 genfscon sysfs /module/msm_thermal                                      u:object_r:sysfs_thermal:s0
 genfscon sysfs /module/printk/parameters/console_suspend                u:object_r:sysfs_console_suspend:s0


### PR DESCRIPTION
Crosshatch sepolicy labels thermals this way as well.

**EDIT:**
Allow `appdomain`(which encompasses all apps) to read thermals from `sysfs_thermal`.

<strike>Helps with certain apps trying to read thermal values through /sys/class instead of /sys/devices/virtual</strike>