### PR TITLE
genfs_contexts: Label /sys/class/thermal

### DIFF
--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -32,6 +32,7 @@ genfscon sysfs /devices/soc/soc:qcom,kgsl-hyp                           u:object
 genfscon sysfs /devices/soc/soc:qcom,ipa_fws@1e08000                    u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/virtual/rotator/mdss_rotator                    u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/soc/0.qcom,rmtfs_sharedmem                      u:object_r:sysfs_rmtfs:s0
+genfscon sysfs /class/thermal                                           u:object_r:sysfs_thermal:s0
 genfscon sysfs /devices/virtual/thermal                                 u:object_r:sysfs_thermal:s0
 genfscon sysfs /module/msm_thermal                                      u:object_r:sysfs_thermal:s0
 genfscon sysfs /module/printk/parameters/console_suspend                u:object_r:sysfs_console_suspend:s0


### PR DESCRIPTION
Crosshatch sepolicy does it this way as well.

Helps with certain apps trying to read thermal values through /sys/class instead of /sys/devices/virtual