### PR TITLE
Allow apps to access thermal data

### DIFF
--- a/vendor/untrusted_app_all.te
+++ b/vendor/untrusted_app_all.te
@@ -1,3 +1,5 @@
 # suppress spurious denials
 dontaudit untrusted_app_all sysfs_zram:dir search;
 dontaudit untrusted_app_all sysfs_zram:file r_file_perms;
+dontaudit untrusted_app_all debugfs_wakeup_sources:file read;
+dontaudit untrusted_app_all proc_loadavg:file read;

--- a/vendor/untrusted_app_all.te
+++ b/vendor/untrusted_app_all.te
@@ -1,5 +1,13 @@
+# This file defines the rules shared by all untrusted app domains except
+# apps which target the v2 security sandbox (ephemeral_app for instant apps,
+# untrusted_v2_app for fully installed v2 apps).
+
 # suppress spurious denials
 dontaudit untrusted_app_all sysfs_zram:dir search;
 dontaudit untrusted_app_all sysfs_zram:file r_file_perms;
 dontaudit untrusted_app_all debugfs_wakeup_sources:file read;
 dontaudit untrusted_app_all proc_loadavg:file read;
+
+# Allow diagnostics apps to read thermals
+allow untrusted_app_all sysfs_thermal:dir { search read open };
+allow untrusted_app_all sysfs_thermal:file { getattr read open };


### PR DESCRIPTION
Dependent on https://github.com/sonyxperiadev/device-sony-sepolicy/pull/471