### PR TITLE
[o-mr1] dsp: Rename qdsp_file to adsprpcd_file

### DIFF
--- a/adsprpcd.te
+++ b/adsprpcd.te
@@ -10,4 +10,4 @@ allow adsprpcd system_file:dir r_dir_perms;
 allow adsprpcd vendor_file:dir r_dir_perms;
 
 # For reading dir/files on /dsp
-r_dir_file(adsprpcd, qdsp_file)
+r_dir_file(adsprpcd, adsprpcd_file)

--- a/cdsprpcd.te
+++ b/cdsprpcd.te
@@ -5,4 +5,4 @@ init_daemon_domain(cdsprpcd)
 
 allow cdsprpcd ion_device:chr_file { open read };
 allow cdsprpcd qdsp_device:chr_file { ioctl open read };
-allow cdsprpcd qdsp_file:dir { getattr read };
+allow cdsprpcd adsprpcd_file:dir { getattr read };

--- a/file.te
+++ b/file.te
@@ -31,6 +31,7 @@ type qmuxd_socket, file_type;
 type netmgrd_socket, file_type;
 type powerhal_socket, file_type;
 type cashsvr_socket, file_type;
+type adsprpcd_file, file_type, mlstrustedobject;
 type qdsp_file, file_type, mlstrustedobject;
 type tad_socket, file_type;
 

--- a/file_contexts
+++ b/file_contexts
@@ -137,7 +137,7 @@
 /data/vendor/camera(/.*)?              u:object_r:camera_data_file:s0
 
 # /
-/dsp(/.*)?                u:object_r:qdsp_file:s0
+/dsp(/.*)?                u:object_r:adsprpcd_file:s0
 
 # files in firmware
 /firmware(/.*)?           u:object_r:firmware_file:s0

--- a/init.te
+++ b/init.te
@@ -3,7 +3,7 @@ allow init tmpfs:lnk_file create;
 allow init configfs:file rw_file_perms;
 allow init configfs:lnk_file { create unlink };
 
-allow init { firmware_file bt_firmware_file persist_file qdsp_file }:dir mounton;
+allow init { firmware_file bt_firmware_file persist_file qdsp_file adsprpcd_file }:dir mounton;
 allow init proc_irq:file w_file_perms;
 
 dontaudit init kernel:system module_request;


### PR DESCRIPTION
We can reuse the adsprpcd_file label and simplify the rules

Why backport to o-mr1? Some devices are still stuck on Oreo. Once someone decides to upgrade them to Pie, they will have issues because we did the change back to `adsprpcd_file` on Pie already.
This change preempts any issues. File relabeling is still allowed on Oreo, so this change should be fine.