### PR TITLE
hal_audio_default: Call powerhal over binder

### DIFF
--- a/vendor/hal_audio_default.te
+++ b/vendor/hal_audio_default.te
@@ -1,10 +1,11 @@
 allow hal_audio_default hal_power_default:unix_stream_socket connectto;
 allow hal_audio_default powerhal_socket:sock_file write;
 allow hal_audio_default powerhal_socket:dir { open read search };
+binder_call(hal_audio_default, hal_power_default)
 
 allow hal_audio_default audio_vendor_data_file:dir rw_dir_perms;
 allow hal_audio_default audio_vendor_data_file:file create_file_perms;
 
-allow hal_audio_default sysfs_soc:dir r_dir_perms;
-allow hal_audio_default sysfs_soc:file r_file_perms;
+r_dir_file(hal_audio_default, sysfs_soc)
+
 allow hal_audio_default hal_power_hwservice:hwservice_manager find;


### PR DESCRIPTION
Denial:
`avc: denied { call } for comm="writer" scontext=u:r:hal_audio_default:s0 
 tcontext=u:r:hal_power_default:s0 tclass=binder`

(Also prettify the access to `sysfs_soc`)