### PR TITLE
shell: tune powerhal and CASH via props

### DIFF
--- a/vendor/shell.te
+++ b/vendor/shell.te
@@ -1,2 +1,5 @@
 # To allow non-root to find power_supply management info
 allow shell sysfs_msm_subsys:dir search;
+
+# Allow non-root to tune powerhal
+set_prop(shell, vendor_powerhal_prop)

--- a/vendor/shell.te
+++ b/vendor/shell.te
@@ -1,5 +1,6 @@
 # To allow non-root to find power_supply management info
 allow shell sysfs_msm_subsys:dir search;
 
-# Allow non-root to tune powerhal
+# Allow non-root to tune powerhal and CASH
 set_prop(shell, vendor_powerhal_prop)
+set_prop(shell, vendor_camera_prop)


### PR DESCRIPTION
Allow non-root to tune powerhal and CASH via setting props.

Dependent on https://github.com/sonyxperiadev/device-sony-sepolicy/pull/476 for the powerhal prop label