### PR TITLE
Cleanup unused file types and remove private crash_dump policy

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -14,5 +14,4 @@
   vndservice_manager_type
 - b/77868789: netd tethering: Remove once fixed upstream
 - b/867711: webview_zygote: Fix socket call to parent in code
-- b/867710: crash_dump: Remove once fixed upstream
 - b/124102550: system_server: Remove once fixed upstream

--- a/private/crash_dump.te
+++ b/private/crash_dump.te
@@ -1,3 +1,0 @@
-# TODO(b/867710): Remove this once fixed upstream.
-# See https://r.android.com/867710
-allow crash_dump resourcecache_data_file:file read;

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -1,5 +1,4 @@
 type sysfs_camera, sysfs_type, fs_type;
-type sysfs_clkscale, sysfs_type, fs_type;
 type sysfs_console_suspend, sysfs_type, fs_type;
 type sysfs_fingerprint, sysfs_type, fs_type;
 type sysfs_graphics, sysfs_type, fs_type;
@@ -13,7 +12,6 @@ type sysfs_timestamp_switch, sysfs_type, fs_type;
 type sysfs_addrsetup, sysfs_type, fs_type;
 type sysfs_bluetooth, sysfs_type, fs_type;
 type sysfs_pcc_profile, sysfs_type, fs_type;
-type sysfs_timekeep, sysfs_type, fs_type;
 type sysfs_usb_supply, sysfs_type, fs_type;
 type sysfs_input_name, sysfs_type, fs_type;
 type sysfs_input_control, sysfs_type, fs_type;


### PR DESCRIPTION
### Remove private crash_dump policy

The file descriptor for the resource cache file seems to be leaking, so access to it is not the correct solution.
See Nick Kralevich's comment on [r.android.com/867710](https://r.android.com/867710)

### Remove unused file types
`sysfs_clkscale` and `sysfs_timekeep` weren't used anywhere, not even in platform sepolicy.