### PR TITLE
Specific powerHAL policy, sscrpcd file reading and audio BT property reading

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -1,6 +1,7 @@
 type sysfs_camera, sysfs_type, fs_type;
 type sysfs_clkscale, sysfs_type, fs_type;
 type sysfs_console_suspend, sysfs_type, fs_type;
+type sysfs_esoc, sysfs_type, fs_type;
 type sysfs_fingerprint, sysfs_type, fs_type;
 type sysfs_graphics, sysfs_type, fs_type;
 type sysfs_mdss_mdp_caps, sysfs_type, fs_type;
@@ -8,8 +9,9 @@ type sysfs_msm_subsys, sysfs_type, fs_type;
 type sysfs_msm_subsys_restart, sysfs_type, fs_type;
 type sysfs_rmtfs, sysfs_type, fs_type;
 type sysfs_soc, sysfs_type, fs_type;
-type sysfs_esoc, sysfs_type, fs_type;
+type sysfs_system_sleep_stats, sysfs_type, fs_type;
 type sysfs_timestamp_switch, sysfs_type, fs_type;
+
 type sysfs_addrsetup, sysfs_type, fs_type;
 type sysfs_bluetooth, sysfs_type, fs_type;
 type sysfs_pcc_profile, sysfs_type, fs_type;

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -26,6 +26,7 @@ type debugfs_rpm, debugfs_type, fs_type;
 type debugfs_rmt_storage, debugfs_type, fs_type;
 type debugfs_mdp, debugfs_type, fs_type;
 type debugfs_icnss, debugfs_type, fs_type;
+type debugfs_wlan, debugfs_type, fs_type;
 
 type location_vendor_data_file, file_type, data_file_type;
 type cashsvr_vendor_data_file, file_type, data_file_type;

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -8,6 +8,7 @@ type sysfs_mdss_mdp_caps, sysfs_type, fs_type;
 type sysfs_msm_subsys, sysfs_type, fs_type;
 type sysfs_msm_subsys_restart, sysfs_type, fs_type;
 type sysfs_rmtfs, sysfs_type, fs_type;
+type sysfs_rpm, sysfs_type, fs_type;
 type sysfs_soc, sysfs_type, fs_type;
 type sysfs_system_sleep_stats, sysfs_type, fs_type;
 type sysfs_timestamp_switch, sysfs_type, fs_type;

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -60,6 +60,8 @@ genfscon sysfs /module/diagchar                                         u:object
 genfscon sysfs /kernel/irq_helper/irq_blacklist_on                      u:object_r:sysfs_irq:s0
 genfscon sysfs /kernel/boot_wlan/boot_wlan                              u:object_r:sysfs_boot_wlan:s0
 
+genfscon sysfs /power/system_sleep/stats                                u:object_r:sysfs_system_sleep_stats:s0
+
 genfscon debugfs /kgsl/proc                           u:object_r:debugfs_kgsl:s0
 genfscon debugfs /clk/debug_suspend                   u:object_r:debugfs_clk:s0
 genfscon debugfs /wlan                                u:object_r:debugfs_wlan:s0

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -62,6 +62,8 @@ genfscon sysfs /kernel/boot_wlan/boot_wlan                              u:object
 
 genfscon debugfs /kgsl/proc                           u:object_r:debugfs_kgsl:s0
 genfscon debugfs /clk/debug_suspend                   u:object_r:debugfs_clk:s0
+genfscon debugfs /wlan                                u:object_r:debugfs_wlan:s0
+genfscon debugfs /wlan0                               u:object_r:debugfs_wlan:s0
 
 genfscon debugfs /rpm_stats                           u:object_r:debugfs_rpm:s0
 genfscon debugfs /rpm_master_stats                    u:object_r:debugfs_rpm:s0

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -60,6 +60,7 @@ genfscon sysfs /module/diagchar                                         u:object
 genfscon sysfs /kernel/irq_helper/irq_blacklist_on                      u:object_r:sysfs_irq:s0
 genfscon sysfs /kernel/boot_wlan/boot_wlan                              u:object_r:sysfs_boot_wlan:s0
 
+genfscon sysfs /power/rpmh_stats/master_stats                           u:object_r:sysfs_rpm:s0
 genfscon sysfs /power/system_sleep/stats                                u:object_r:sysfs_system_sleep_stats:s0
 
 genfscon debugfs /kgsl/proc                           u:object_r:debugfs_kgsl:s0

--- a/vendor/hal_audio_default.te
+++ b/vendor/hal_audio_default.te
@@ -9,3 +9,5 @@ allow hal_audio_default audio_vendor_data_file:file create_file_perms;
 r_dir_file(hal_audio_default, sysfs_soc)
 
 allow hal_audio_default hal_power_hwservice:hwservice_manager find;
+
+get_prop(hal_audio_default, bluetooth_prop)

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -5,3 +5,6 @@ allow hal_power_default sysfs_devices_system_cpu:file w_file_perms;
 
 # Read persist.vendor.powerhal.*
 get_prop(hal_power_default, vendor_powerhal_prop)
+
+# Read sysfs stats files:
+r_dir_file(hal_power_default, debugfs_wlan)

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -3,9 +3,5 @@ allow hal_power_default powerhal_socket:sock_file create_file_perms;
 
 allow hal_power_default sysfs_devices_system_cpu:file w_file_perms;
 
-allow hal_power_default debugfs_rpm:file rw_file_perms;
-
-allow hal_power_default sysfs:file rw_file_perms;
-
 # Read persist.vendor.powerhal.*
 get_prop(hal_power_default, vendor_powerhal_prop)

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -3,5 +3,9 @@ allow hal_power_default powerhal_socket:sock_file create_file_perms;
 
 allow hal_power_default sysfs_devices_system_cpu:file w_file_perms;
 
+allow hal_power_default debugfs_rpm:file rw_file_perms;
+
+allow hal_power_default sysfs:file rw_file_perms;
+
 # Read persist.vendor.powerhal.*
 get_prop(hal_power_default, vendor_powerhal_prop)

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -8,3 +8,4 @@ get_prop(hal_power_default, vendor_powerhal_prop)
 
 # Read sysfs stats files:
 r_dir_file(hal_power_default, debugfs_wlan)
+allow hal_power_default sysfs_system_sleep_stats:file r_file_perms;

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -9,3 +9,4 @@ get_prop(hal_power_default, vendor_powerhal_prop)
 # Read sysfs stats files:
 r_dir_file(hal_power_default, debugfs_wlan)
 allow hal_power_default sysfs_system_sleep_stats:file r_file_perms;
+allow hal_power_default sysfs_rpm:file r_file_perms;

--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -18,3 +18,4 @@ allow sscrpcd self:socket create;
 allow sscrpcd sysfs_msm_subsys:dir { read search };
 allow sscrpcd mnt_vendor_file:dir search;
 allow sscrpcd sysfs_soc:dir search;
+allow sscrpcd sysfs_soc:file r_file_perms;

--- a/vendor/tad.te
+++ b/vendor/tad.te
@@ -32,6 +32,8 @@ wakelock_use(tad)
 #To create the folders in /persist
 allow tad persist_file:dir create_dir_perms;
 
+allow tad vendor_data_file:dir create_dir_perms;
+
 #For system folder entries
 r_dir_file(tad, rfs_system_file)
 allow tad rfs_system_file:lnk_file r_file_perms;
@@ -51,6 +53,7 @@ r_dir_file(tad, vendor_firmware_file)
 
 #For dropping permisions from root and wakelock
 allow tad self:capability {
+    chown
     setuid
     setgid
     setpcap


### PR DESCRIPTION
Revert PowerHAL read **and write** access to all of `sysfs` (and `debugfs_rpm`). Also note that no `debugfs_rpm` denials were found, only those to `/sys/power/rpmh_stats/master_stats` which has been labeled `sysfs_rpm`.

See commit descriptions for denials and approval justifications.