### PR TITLE
[WIP] tad: Control /data/vendor/hlos_rfs/ files

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -58,7 +58,6 @@ type persist_time_file, file_type, vendor_persist_type;
 type rfs_system_file, file_type, vendor_file_type;
 
 type rfs_file, file_type, data_file_type;
-type rfs_shared_hlos_file, file_type, data_file_type;
 
 type audio_vendor_data_file, file_type, data_file_type;
 type bluetooth_vendor_data_file, file_type, data_file_type;

--- a/vendor/tad.te
+++ b/vendor/tad.te
@@ -17,7 +17,6 @@ r_dir_file(tad, proc)
 
 #The files created by tftp_server process in the /data folder will have type rfs_file
 type_transition tad system_data_file:{ dir file } rfs_file;
-type_transition tad system_data_file:dir rfs_shared_hlos_file "hlos_rfs";
 #Same for files in /data/vendor/
 type_transition tad vendor_data_file:{ dir file } rfs_file;
 
@@ -38,9 +37,6 @@ allow tad rfs_system_file:lnk_file r_file_perms;
 allow tad vendor_data_file:dir { add_name write };
 allow tad rfs_file:dir create_dir_perms;
 allow tad rfs_file:file create_file_perms;
-
-allow tad rfs_shared_hlos_file:dir create_dir_perms;
-allow tad rfs_shared_hlos_file:file create_file_perms;
 
 allow tad persist_file:dir search;
 allow tad persist_rfs_file:dir create_dir_perms;

--- a/vendor/tad.te
+++ b/vendor/tad.te
@@ -18,10 +18,11 @@ r_dir_file(tad, proc)
 #The files created by tftp_server process in the /data folder will have type rfs_file
 type_transition tad system_data_file:{ dir file } rfs_file;
 type_transition tad system_data_file:dir rfs_shared_hlos_file "hlos_rfs";
+#Same for files in /data/vendor/
+type_transition tad vendor_data_file:{ dir file } rfs_file;
 
 #The files created by tftp_server process in the /persist folder will have type persist_rfs_file
 type_transition tad persist_rfs_file:{ dir file } persist_rfs_file;
-type_transition tad persist_rfs_file:dir persist_rfs_file "hlos_rfs";
 
 #For QMI sockets and IPCR Sockets
 allow tad self:socket create_socket_perms_no_ioctl;
@@ -29,22 +30,19 @@ allow tad self:socket create_socket_perms_no_ioctl;
 #For Wakelocks
 wakelock_use(tad)
 
-#To create the folders in /persist
-allow tad persist_file:dir create_dir_perms;
-
-allow tad vendor_data_file:dir create_dir_perms;
-
 #For system folder entries
 r_dir_file(tad, rfs_system_file)
 allow tad rfs_system_file:lnk_file r_file_perms;
 
 #For data folder entries
+allow tad vendor_data_file:dir { add_name write };
 allow tad rfs_file:dir create_dir_perms;
 allow tad rfs_file:file create_file_perms;
 
 allow tad rfs_shared_hlos_file:dir create_dir_perms;
 allow tad rfs_shared_hlos_file:file create_file_perms;
 
+allow tad persist_file:dir search;
 allow tad persist_rfs_file:dir create_dir_perms;
 allow tad persist_rfs_file:file create_file_perms;
 


### PR DESCRIPTION
Same as /data/hlos_rfs, tad now creates and uses files in /data/vendor/hlos_rfs.

The type_transition rule means any files/dirs tad creates in /data/vendor will use the rfs_file label.

When the broader type_transition rule without "hlos_rfs" as the object_name at the end is in place, no need to specify hlos_rfs again.

See https://selinuxproject.org/page/TypeStatements
`type_transition source_type target_type : class default_type object_name;`