### PR TITLE
Label ro.wifi. props

### DIFF
--- a/vendor/property.te
+++ b/vendor/property.te
@@ -14,4 +14,5 @@ type vendor_powerhal_prop, property_type;
 type vendor_radio_prop, property_type;
 type vendor_usb_config_prop, property_type;
 type vendor_usb_prop, property_type;
+type vendor_wifi_prop, property_type;
 type wc_prop, property_type;

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -14,6 +14,7 @@ persist.vendor.usb.             u:object_r:vendor_usb_prop:s0
 persist.vendor.usb.config       u:object_r:vendor_usb_config_prop:s0
 ro.vendor.bt.                   u:object_r:vendor_bluetooth_prop:s0
 ro.vendor.ril.                  u:object_r:vendor_radio_prop:s0
+ro.wifi.                        u:object_r:vendor_wifi_prop:s0
 sensors.                        u:object_r:sensors_prop:s0
 sys.keymaster.loaded            u:object_r:keymaster_prop:s0
 sys.listeners.registered        u:object_r:tee_listener_prop:s0


### PR DESCRIPTION
This is needed for accessing ro.wifi.addr_path

Why not re-use AOSP's regular "wifi_prop" label?
wifi_prop is reserved for platform/coredomain access, but we want vendor programs like macaddrsetup to use it.