### PR TITLE
Regulate /dev/diag access in user builds

### DIFF
--- a/vendor/domain.te
+++ b/vendor/domain.te
@@ -1,7 +1,3 @@
-userdebug_or_eng(`
-  allow domain diag_device:chr_file rw_file_perms;
-')
-
 # In order for /sys/kernel/debug/kgsl/proc/<pid>/mem
 # to be created for memory tracking, the domain of
 # the tracked process must have permission to search

--- a/vendor/hal_bluetooth_default.te
+++ b/vendor/hal_bluetooth_default.te
@@ -1,5 +1,10 @@
 allow hal_bluetooth_default bt_device:chr_file rw_file_perms;
 allow hal_bluetooth_default serial_device:chr_file rw_file_perms;
+userdebug_or_eng(`
+  allow hal_bluetooth_default diag_device:chr_file { read write };
+')
+# Ignore in user builds
+dontaudit hal_bluetooth_default diag_device:chr_file { read write };
 
 allow hal_bluetooth_default bluetooth_vendor_data_file:dir create_dir_perms;
 allow hal_bluetooth_default bluetooth_vendor_data_file:file create_file_perms;

--- a/vendor/hal_gnss_qti.te
+++ b/vendor/hal_gnss_qti.te
@@ -18,6 +18,8 @@ unix_socket_connect(hal_gnss_qti, qmuxd, qmuxd)
 userdebug_or_eng(`
   allow hal_gnss_qti diag_device:chr_file { read write };
 ')
+# Ignore in user builds
+dontaudit hal_gnss_qti diag_device:chr_file { read write };
 
 binder_call(hal_gnss_qti, per_mgr)
 

--- a/vendor/hal_sensors_default.te
+++ b/vendor/hal_sensors_default.te
@@ -2,7 +2,11 @@
 allow hal_sensors_default self:socket { create ioctl read write };
 allowxperm hal_sensors_default self:socket ioctl msm_sock_ipc_ioctls;
 
-allow hal_sensors_default diag_device:chr_file rw_file_perms;
+userdebug_or_eng(`
+  allow hal_sensors_default diag_device:chr_file rw_file_perms;
+')
+# Ignore in user builds
+dontaudit hal_sensors_default diag_device:chr_file { read write };
 
 r_dir_file(hal_sensors_default, sysfs_msm_subsys);
 allow hal_sensors_default sysfs_esoc:dir r_dir_perms;

--- a/vendor/hal_sensors_default.te
+++ b/vendor/hal_sensors_default.te
@@ -2,6 +2,8 @@
 allow hal_sensors_default self:socket { create ioctl read write };
 allowxperm hal_sensors_default self:socket ioctl msm_sock_ipc_ioctls;
 
+allow hal_sensors_default diag_device:chr_file rw_file_perms;
+
 r_dir_file(hal_sensors_default, sysfs_msm_subsys);
 allow hal_sensors_default sysfs_esoc:dir r_dir_perms;
 

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -52,6 +52,8 @@ unix_socket_connect(netmgrd, qmuxd, qmuxd)
 userdebug_or_eng(`
   allow netmgrd diag_device:chr_file { read write };
 ')
+# Ignore in user builds
+dontaudit netmgrd diag_device:chr_file { read write };
 
 allow netmgrd sysfs_net:dir r_dir_perms;
 allow netmgrd sysfs_net:file rw_file_perms;

--- a/vendor/sensors.te
+++ b/vendor/sensors.te
@@ -8,6 +8,10 @@ allow sensors self:capability {
     net_bind_service
 };
 
+userdebug_or_eng(`
+  allow sensors diag_device:chr_file rw_file_perms;
+')
+
 allow sensors self:socket create_socket_perms;
 allowxperm sensors self:socket ioctl msm_sock_ipc_ioctls;
 

--- a/vendor/sensors.te
+++ b/vendor/sensors.te
@@ -31,3 +31,4 @@ r_dir_file(sensors, sysfs_soc)
 r_dir_file(sensors, sysfs_esoc)
 
 dontaudit sensors kernel:system { module_request };
+dontaudit sensors diag_device:chr_file rw_file_perms;


### PR DESCRIPTION
`hal_sensors_default`, `hal_gnss_qti`, `netmgrd` and `sensors` should only receive access to `/dev/diag` in `userdebug` or `eng` builds and all other access should be ignored.