### PR TITLE
addrsetup: Allow SIOCSIFHWADDR ioctl

### DIFF
--- a/vendor/addrsetup.te
+++ b/vendor/addrsetup.te
@@ -20,4 +20,6 @@ allow addrsetup wpa_data_file:file create_file_perms;
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
 allow addrsetup self:capability { net_admin net_raw };
-allow addrsetup self:udp_socket create;
+allow addrsetup self:udp_socket { create ioctl };
+# If compiled with BRCFMAC:
+allowxperm addrsetup self:udp_socket ioctl SIOCSIFHWADDR;


### PR DESCRIPTION
If compiled with `BRCFMAC`, `macaddrsetup` uses an `ioctl` to get the WLAN mac address, see
https://github.com/sonyxperiadev/macaddrsetup/blob/d413798801a15dc5633b2beb17852d39e608dc0a/macaddrsetup.c#L154

The ioctl is already defined in AOSP sepolicy so we can set it using `allowxperm`.