### PR TITLE
cdsprpcd: ioctl to ion_device, read vendor_file dirs

### DIFF
--- a/vendor/cdsprpcd.te
+++ b/vendor/cdsprpcd.te
@@ -6,3 +6,5 @@ init_daemon_domain(cdsprpcd)
 allow cdsprpcd ion_device:chr_file { open read ioctl };
 allow cdsprpcd qdsp_device:chr_file { ioctl open read };
 allow cdsprpcd adsprpcd_file:dir { getattr read };
+
+allow cdsprpcd vendor_file:dir r_dir_perms;

--- a/vendor/cdsprpcd.te
+++ b/vendor/cdsprpcd.te
@@ -3,6 +3,6 @@ type cdsprpcd_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(cdsprpcd)
 
-allow cdsprpcd ion_device:chr_file { open read };
+allow cdsprpcd ion_device:chr_file { open read ioctl };
 allow cdsprpcd qdsp_device:chr_file { ioctl open read };
 allow cdsprpcd adsprpcd_file:dir { getattr read };


### PR DESCRIPTION
- Allow `ioctl` to `ion_device`
- Allow reading `vendor_file` dirs