### PR TITLE
sscrpcd: Allow more file+device access, dontaudit module_request

### DIFF
--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -22,3 +22,5 @@ allow sscrpcd sysfs_msm_subsys:dir { search open read };
 allow sscrpcd sysfs_msm_subsys:file { open read };
 allow sscrpcd sysfs_soc:dir search;
 allow sscrpcd sysfs_soc:file r_file_perms;
+
+dontaudit sscrpcd kernel:system module_request;

--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -4,18 +4,18 @@ type sscrpcd_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(sscrpcd)
 
-allow sscrpcd self:capability {
-    net_bind_service
-};
+allow sscrpcd self:capability net_bind_service;
+
+allow sscrpcd self:socket create;
+
+allow sscrpcd qdsp_device:chr_file { open read ioctl };
+allow sscrpcd ion_device:chr_file read;
 
 allow sscrpcd persist_file:dir search;
 allow sscrpcd persist_sensors_file:dir create_dir_perms;
 allow sscrpcd persist_sensors_file:file create_file_perms;
-allow sscrpcd qdsp_device:chr_file { open read };
-allow sscrpcd qdsp_device:chr_file ioctl;
-allow sscrpcd ion_device:chr_file read;
-allow sscrpcd self:socket create;
-allow sscrpcd sysfs_msm_subsys:dir { read search };
 allow sscrpcd mnt_vendor_file:dir search;
+
+allow sscrpcd sysfs_msm_subsys:dir { read search };
 allow sscrpcd sysfs_soc:dir search;
 allow sscrpcd sysfs_soc:file r_file_perms;

--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -9,13 +9,16 @@ allow sscrpcd self:capability net_bind_service;
 allow sscrpcd self:socket create;
 
 allow sscrpcd qdsp_device:chr_file { open read ioctl };
-allow sscrpcd ion_device:chr_file read;
+allow sscrpcd ion_device:chr_file { open read ioctl };
 
 allow sscrpcd persist_file:dir search;
 allow sscrpcd persist_sensors_file:dir create_dir_perms;
 allow sscrpcd persist_sensors_file:file create_file_perms;
-allow sscrpcd mnt_vendor_file:dir search;
+allow sscrpcd mnt_vendor_file:dir { search open read };
+allow sscrpcd vendor_file:dir read;
+allow sscrpcd adsprpcd_file:dir read;
 
-allow sscrpcd sysfs_msm_subsys:dir { read search };
+allow sscrpcd sysfs_msm_subsys:dir { search open read };
+allow sscrpcd sysfs_msm_subsys:file { open read };
 allow sscrpcd sysfs_soc:dir search;
 allow sscrpcd sysfs_soc:file r_file_perms;


### PR DESCRIPTION
- Prettify: Arrange perms logically
- Allow more file and device access (not all denials listed, but they were tested on tama by Alin)
- `dontaudit module_request`