### PR TITLE
vendor_init: Label and access more proc+sysfs files

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -1,4 +1,5 @@
 type sysfs_addrsetup, sysfs_type, fs_type;
+type sysfs_block_queue, fs_type, sysfs_type;
 type sysfs_bluetooth, sysfs_type, fs_type;
 type sysfs_boot_wlan, fs_type, sysfs_type;
 type sysfs_camera, sysfs_type, fs_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -114,6 +114,8 @@
 /sys/devices/virtual/input/input[0-9]+/als_(.*)+                                             u:object_r:sysfs_rgbc_sensor:s0
 # Real-time-clock
 /sys/class/rtc(/.*)?                                                                         u:object_r:sysfs_rtc:s0
+# Disk schedulers
+/sys/block/[^/]+/queue(/.*)?                                                                 u:object_r:sysfs_block_queue:s0
 
 ###############################################
 # same-process HAL files and their dependencies

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -23,6 +23,9 @@ allow vendor_init proc_sched:file write;
 allow vendor_init proc_irq:file write;
 allow vendor_init proc_kernel_printk:file write;
 
+# Set disk parameters
+allow vendor_init sysfs_block_queue:file { open setattr write };
+
 allow vendor_init persist_file:lnk_file read;
 # Create and chown /(mnt/vendor/)persist/battery/ folder for health HAL
 allow vendor_init persist_battery_file:dir create_dir_perms;


### PR DESCRIPTION
- Label `/sys/block/*/queue/*`
  A broad regex was chosen as not to clash with omni's sepolicy which uses sysfs_block_scheduler.
  See https://gerrit.omnirom.org/c/android_vendor_omni/+/33309
- vendor_init: Write disk queue parameters
  tama's (and yoshino's) `rootdir/vendor/etc/init/init.$DEVICE.rc` writes to `/sys/block/sd[ab]/queue` since device-sony-tama@93f8d1dbcd7b1eb69dcc7fed4040f0ce295a301f