### PR TITLE
WiFi debugfs denials

### DIFF
--- a/vendor/hal_wifi_default.te
+++ b/vendor/hal_wifi_default.te
@@ -1,4 +1,6 @@
 # /sys/kernel/boot_wlan/boot_wlan
 allow hal_wifi_default sysfs_boot_wlan:file w_file_perms;
 
+r_dir_file(hal_wifi_default, debugfs_wlan)
+
 allow hal_wifi_default kernel:system module_request;

--- a/vendor/kernel.te
+++ b/vendor/kernel.te
@@ -4,3 +4,7 @@ userdebug_or_eng(`
 ')
 
 dontaudit kernel kernel:system module_request;
+
+# A kernel worker has to read from /d/wlan{,0}/,
+# otherwise debug files are not created there.
+r_dir_file(kernel, debugfs_wlan)


### PR DESCRIPTION
These commits address new denials introduced after cherry-picking https://github.com/sonyxperiadev/device-sony-sepolicy/pull/480. which relabels `/d/wlan{,0}/` to `debugfs_wlan`.
Userdebug builds do not regulate access to `debugfs`, so these are only found after making the labels on those files more specific.