### PR TITLE
vendor: file_contexts: add libgralloccore

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -149,6 +149,7 @@
 /(system/vendor|vendor|odm)/lib(64)?/libadsprpc\.so                   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libcdsprpc\.so                   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libsdsprpc\.so                   u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/libgralloccore\.so               u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libgrallocutils\.so              u:object_r:same_process_hal_file:s0
 
 # RenderScript dependencies.


### PR DESCRIPTION
On devices using the 7.3 display hal, an additional gralloc library exists.
The library is accessed by surfaceflinger similar to libgrallocutils, so make it have the same context.