### PR TITLE
Revert "netmgrd: Remove superfluous get_prop"

### DIFF
--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -28,6 +28,7 @@ allow netmgrd self:capability {
 
 set_prop(netmgrd, net_radio_prop)
 set_prop(netmgrd, net_rmnet_prop)
+get_prop(netmgrd, hwservicemanager_prop)
 
 # communicate with netd
 unix_socket_connect(netmgrd, netd, netd)


### PR DESCRIPTION
This reverts commit aabf2fe740e5e397aa9adb1272134ed6531be26d.

The wakelock_use() macro only includes `get_prop($1, hwservicemanager_prop)` in Android Q but not yet in Pie

(Thx Marijn)