### PR TITLE
Q compatability improvements and cleanup

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -16,3 +16,5 @@
 - b/867711: webview_zygote: Fix socket call to parent in code
 - b/124102550: system_server: Remove once fixed upstream
 - b/netutils-lock: Remove lock on xtables.lock once netutils wrappers are available
+- b/netmgrd-system: Remove system file access once netmgrd does no longer
+  execute system files

--- a/BUGSs.md
+++ b/BUGSs.md
@@ -18,3 +18,5 @@
 - b/netutils-lock: Remove lock on xtables.lock once netutils wrappers are available
 - b/netmgrd-system: Remove system file access once netmgrd does no longer
   execute system files
+- b/idc-kl: Remove vendor_idc_file and vendor_keylayout_file labels as they are
+  labeled by AOSP already in Q

--- a/BUGSs.md
+++ b/BUGSs.md
@@ -15,3 +15,4 @@
 - b/77868789: netd tethering: Remove once fixed upstream
 - b/867711: webview_zygote: Fix socket call to parent in code
 - b/124102550: system_server: Remove once fixed upstream
+- b/netutils-lock: Remove lock on xtables.lock once netutils wrappers are available

--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 This sepolicy is suitable for SODP supported devices when building on AOSP. Where
 possible, we follow the structure, style, and naming conventions found in the sepolicy
-written for Google devices. The current best comparison is the `wahoo` sepolicy.
+written for Google devices.
 
 When submitting patches please include the following in the commit message:
 
 1. The AVC denial you wish to resolve
 2. Why you think this is the correct sepolicy
 3. Steps to reproduce the denial
-4. Ping @AdFad666 for review.
 
 Failure to include the above may result in your patch being rejected.
 
@@ -33,13 +32,15 @@ See `LICENSE.md`.
 1. Documentation, if any
 2. `domain`, `mydomain_exec`
 3. `init_daemon_domain` or `app_domain`
-4. `typeattribute` violation declarations
-5. `binder_use()` and equivalents
-6. `binder_call()` and equivalents
-7. `add_service()` and equivalents, `hal_server_domain()`
-8. Miscellaneous things like `wakelock_use()` and `capability`
-9. `get/set_prop()`
-10. `unix_socket_connect()` and other socket stuff
-11. `device` access
-11. File permissions, ioctl
-12. `dontaudit`
+3. `hal_server_domain()` and equivalents
+5. `typeattribute` violation declarations
+6. `binder_use()` and equivalents
+7. `binder_call()` and equivalents
+8. `add_service()` and equivalents
+9. Miscellaneous things like `wakelock_use()` and `capability`
+10. `get/set_prop()`
+11. `unix_socket_connect()` and other socket stuff
+12. `device` access
+13. File permissions, ioctl
+14. `kernel` and module requests
+15. `dontaudit`

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -73,9 +73,10 @@ type sensors_vendor_data_file, file_type, data_file_type;
 type timekeep_vendor_data_file, file_type, data_file_type;
 type wifi_vendor_data_file, file_type, data_file_type;
 
-# input files
-type idc_file, file_type, vendor_file_type;
-type keylayout_file, file_type, vendor_file_type;
+# Input files in /vendor/usr/
+# TODO(b/idc-kl): These are labeled by AOSP already in Q
+type vendor_idc_file, file_type, vendor_file_type;
+type vendor_keylayout_file, file_type, vendor_file_type;
 
 # Battery Stats file
 typeattribute sysfs_batteryinfo mlstrustedobject;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -76,8 +76,9 @@
 # files in /vendor
 /(system/vendor|vendor)/rfs(/.*)?                                                            u:object_r:rfs_system_file:s0
 /(system/vendor|vendor)/firmware(/.*)?                                                       u:object_r:vendor_firmware_file:s0
-/(system/vendor|vendor)/usr/idc(/.*)?                                                        u:object_r:idc_file:s0
-/(system/vendor|vendor)/usr/keylayout(/.*)?                                                  u:object_r:keylayout_file:s0
+# TODO(b/idc-kl): These are labeled by AOSP already in Q
+/(system/vendor|vendor)/usr/idc(/.*)?                                                        u:object_r:vendor_idc_file:s0
+/(system/vendor|vendor)/usr/keylayout(/.*)?                                                  u:object_r:vendor_keylayout_file:s0
 /(system/vendor|vendor)/bin/macaddrsetup                                                     u:object_r:addrsetup_exec:s0
 /(system/vendor|vendor)/bin/rdclean\.sh                                                      u:object_r:rdclean_exec:s0
 /(system/vendor|vendor)/bin/init\.qcom\.devstart\.sh                                         u:object_r:init-qcom-devstart-sh_exec:s0

--- a/vendor/hal_audio_default.te
+++ b/vendor/hal_audio_default.te
@@ -1,13 +1,18 @@
+hal_client_domain(hal_audio_default, hal_power)
+
+binder_call(hal_audio_default, hal_power_default)
+
+allow hal_audio_default hal_power_hwservice:hwservice_manager find;
+
+get_prop(hal_audio_default, bluetooth_prop)
+
+# RQBalance-Powerhal
 allow hal_audio_default hal_power_default:unix_stream_socket connectto;
+# RQBalance-Powerhal legacy mode
 allow hal_audio_default powerhal_socket:sock_file write;
 allow hal_audio_default powerhal_socket:dir { open read search };
-binder_call(hal_audio_default, hal_power_default)
 
 allow hal_audio_default audio_vendor_data_file:dir rw_dir_perms;
 allow hal_audio_default audio_vendor_data_file:file create_file_perms;
 
 r_dir_file(hal_audio_default, sysfs_soc)
-
-allow hal_audio_default hal_power_hwservice:hwservice_manager find;
-
-get_prop(hal_audio_default, bluetooth_prop)

--- a/vendor/hal_gatekeeper_qti.te
+++ b/vendor/hal_gatekeeper_qti.te
@@ -32,7 +32,7 @@ hal_server_domain(hal_gatekeeper_qti, hal_gatekeeper)
 type hal_gatekeeper_qti_exec, exec_type, file_type, vendor_file_type;
 init_daemon_domain(hal_gatekeeper_qti)
 
-allow hal_gatekeeper_qti tee_listener_prop:file r_file_perms;
+get_prop(hal_gatekeeper_qti, tee_listener_prop)
 
 # allow tee to load firmware images
 r_dir_file(hal_gatekeeper, vendor_firmware_file)

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -1,10 +1,13 @@
 # Binder access (for display.qservice)
 vndbinder_use(hal_graphics_composer_default)
-allow hal_graphics_composer_default qdisplay_service:service_manager { add find };
 
-allow hal_graphics_composer_default sysfs_mdss_mdp_caps:file r_file_perms;
+binder_call(hal_graphics_composer_default, hal_graphics_allocator_default)
+
+add_service(hal_graphics_composer_default, qdisplay_service)
+add_hwservice(hal_graphics_composer_default, hal_display_config_hwservice)
+allow hal_graphics_composer_default hal_graphics_allocator_hwservice:hwservice_manager find;
+
 allow hal_graphics_composer_default { graphics_device video_device }:chr_file rw_file_perms;
-allow hal_graphics_composer_default hal_display_config_hwservice:hwservice_manager add;
 
 allow hal_graphics_composer_default oemfs:dir search;
 allow hal_graphics_composer_default persist_display_file:dir getattr;
@@ -13,12 +16,9 @@ allow hal_graphics_composer_default persist_file:dir search;
 r_dir_file(hal_graphics_composer_default, sysfs_leds)
 r_dir_file(hal_graphics_composer_default, sysfs_camera)
 r_dir_file(hal_graphics_composer_default, sysfs_msm_subsys)
-
-# HWC_UeventThread
-allow hal_graphics_composer_default self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;
-
+allow hal_graphics_composer_default sysfs_mdss_mdp_caps:file r_file_perms;
 # Access /sys/devices/virtual/graphics/fb0
 r_dir_rw_file(hal_graphics_composer_default, sysfs_graphics)
 
-allow hal_graphics_composer_default hal_graphics_allocator_default:binder call;
-allow hal_graphics_composer_default hal_graphics_allocator_hwservice:hwservice_manager find;
+# HWC_UeventThread
+allow hal_graphics_composer_default self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -1,3 +1,5 @@
+hal_client_domain(hal_graphics_composer_default, hal_graphics_allocator)
+
 # Binder access (for display.qservice)
 vndbinder_use(hal_graphics_composer_default)
 

--- a/vendor/hal_keymaster_qti.te
+++ b/vendor/hal_keymaster_qti.te
@@ -31,7 +31,7 @@ hal_server_domain(hal_keymaster_qti, hal_keymaster)
 type hal_keymaster_qti_exec, exec_type, file_type, vendor_file_type;
 init_daemon_domain(hal_keymaster_qti)
 
-allow hal_keymaster_qti tee_listener_prop:file r_file_perms;
+get_prop(hal_keymaster_qti, tee_listener_prop)
 
 # allow tee to load firmware images
 r_dir_file(hal_keymaster_qti, vendor_firmware_file)

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -4,8 +4,28 @@ type netmgrd_exec, exec_type, vendor_file_type, file_type;
 net_domain(netmgrd)
 init_daemon_domain(netmgrd)
 
+# Allow netutils usage
+domain_auto_trans(netmgrd, netutils_wrapper_exec, netutils_wrapper)
+
+hwbinder_use(netmgrd)
+binder_call(netmgrd, netd)
+
+# Allow netmgrd to use netd HAL
+allow netmgrd system_net_netd_hwservice:hwservice_manager find;
+
+wakelock_use(netmgrd)
+
+allow netmgrd self:capability {
+    net_admin
+    net_raw
+    setgid
+    setpcap
+    setuid
+};
+
 set_prop(netmgrd, net_radio_prop)
 set_prop(netmgrd, net_rmnet_prop)
+get_prop(netmgrd, hwservicemanager_prop)
 
 # communicate with netd
 unix_socket_connect(netmgrd, netd, netd)
@@ -24,17 +44,16 @@ allow netmgrd qmuxd_socket:dir w_dir_perms;
 allow netmgrd qmuxd_socket:sock_file create_file_perms;
 unix_socket_connect(netmgrd, qmuxd, qmuxd)
 
+userdebug_or_eng(`
+  allow netmgrd diag_device:chr_file { read write };
+')
+
 allow netmgrd sysfs_net:dir r_dir_perms;
 allow netmgrd sysfs_net:file rw_file_perms;
 
 r_dir_file(netmgrd, sysfs_msm_subsys)
 r_dir_file(netmgrd, sysfs_soc)
 r_dir_file(netmgrd, sysfs_esoc)
-
-wakelock_use(netmgrd)
-
-# Allow netutils usage
-domain_auto_trans(netmgrd, netutils_wrapper_exec, netutils_wrapper)
 
 allow netmgrd proc_net:file rw_file_perms;
 allow netmgrd netmgr_vendor_data_file:dir rw_dir_perms;
@@ -44,22 +63,12 @@ allow netmgrd netmgr_vendor_data_file:file create_file_perms;
 allow netmgrd system_file:file x_file_perms;
 
 # Acquire lock on /system/etc/xtables.lock
-# Required till netutils wrappers are available
-not_full_treble(`allow netmgrd system_file:file lock;')
-
-allow netmgrd self:capability { net_admin net_raw setgid setpcap setuid };
+# TODO(b/netutils-lock): Required till netutils wrappers are available
+not_full_treble(`
+  allow netmgrd system_file:file lock;
+')
 
 allow netmgrd vendor_toolbox_exec:file rx_file_perms;
 
-# Allow netmgrd to use netd HAL
-allow netmgrd system_net_netd_hwservice:hwservice_manager find;
-get_prop(netmgrd, hwservicemanager_prop)
-binder_call(netmgrd, netd)
-hwbinder_use(netmgrd)
-
 dontaudit netmgrd kernel:system module_request;
 dontaudit netmgrd self:system module_request;
-
-userdebug_or_eng(`
-  allow netmgrd diag_device:chr_file { read write };
-')

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -1,5 +1,10 @@
 type netmgrd, domain;
 type netmgrd_exec, exec_type, vendor_file_type, file_type;
+# TODO(b/netmgrd-system): Remove this once netutils does not
+# execute system files,
+not_full_treble(`
+  typeattribute netmgrd vendor_executes_system_violators;
+')
 
 net_domain(netmgrd)
 init_daemon_domain(netmgrd)
@@ -56,11 +61,17 @@ r_dir_file(netmgrd, sysfs_soc)
 r_dir_file(netmgrd, sysfs_esoc)
 
 allow netmgrd proc_net:file rw_file_perms;
+
 allow netmgrd netmgr_vendor_data_file:dir rw_dir_perms;
 allow netmgrd netmgr_vendor_data_file:file create_file_perms;
 
 # Allow execution of commands in shell
-allow netmgrd system_file:file x_file_perms;
+# TODO(b/netmgrd-system): Remove this once netmgrd does not execute
+# system files, it's a neverallow on Q without
+# vendor_executes_system_violators
+not_full_treble(`
+  allow netmgrd system_file:file x_file_perms;
+')
 
 # Acquire lock on /system/etc/xtables.lock
 # TODO(b/netutils-lock): Required till netutils wrappers are available

--- a/vendor/system_server.te
+++ b/vendor/system_server.te
@@ -6,9 +6,9 @@ allowxperm system_server self:socket ioctl msm_sock_ipc_ioctls;
 
 allow system_server wlan_device:chr_file rw_file_perms;
 
-# input files
-r_dir_file(system_server, idc_file)
-r_dir_file(system_server, keylayout_file)
+# Input files in /vendor/usr/
+r_dir_file(system_server, vendor_idc_file)
+r_dir_file(system_server, vendor_keylayout_file)
 
 # Allow system_server to write to /proc/<pid>/timerslack_ns
 allow system_server appdomain:file w_file_perms;

--- a/vendor/system_server.te
+++ b/vendor/system_server.te
@@ -1,10 +1,10 @@
+binder_call(system_server, hal_camera_default)
+binder_call(system_server, hal_tetheroffload_default)
+
 allow system_server self:socket ioctl;
 allowxperm system_server self:socket ioctl msm_sock_ipc_ioctls;
 
-binder_call(system_server, hal_camera_default)
-
 allow system_server wlan_device:chr_file rw_file_perms;
-binder_call(system_server, hal_tetheroffload_default)
 
 # input files
 r_dir_file(system_server, idc_file)


### PR DESCRIPTION
- README: Update statement order
- `hal_audio_default`: Reorder items
- `hal_gatekeeper_qti`: Use `get_prop` macro (needed for Q)
- `hal_keymaster_qti`: Use `get_prop` macro  (needed for Q)
- `netmgrd`: Prettify policy, reorder items and clean up syntax
- `netmgrd`: Add violator for vendor_file access
  The `vendor_executes_system_violators` attribute name is a bit misleading since it exempts all file operations from the neverallow, not only {execute}.
  (Only for non-full-treble, have to find a proper solution soon)
- `system_server`: Reorder items
- Use AOSP labels for `keylayout` and `idc` files
- `hal_graphics_composer`: Use macros, reorder
- `hal_graphics_composer`: Client domain for `hal_graphics_allocator`