### PR TITLE
Q cleanup: Remove dupplicate allows, allow display access to /mnt/vendor/persist/display

### DIFF
--- a/vendor/hal_audio_default.te
+++ b/vendor/hal_audio_default.te
@@ -1,9 +1,5 @@
 hal_client_domain(hal_audio_default, hal_power)
 
-binder_call(hal_audio_default, hal_power_default)
-
-allow hal_audio_default hal_power_hwservice:hwservice_manager find;
-
 get_prop(hal_audio_default, bluetooth_prop)
 
 # RQBalance-Powerhal

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -20,6 +20,9 @@ r_dir_file(hal_graphics_composer_default, sysfs_msm_subsys)
 allow hal_graphics_composer_default sysfs_mdss_mdp_caps:file r_file_perms;
 # Access /sys/devices/virtual/graphics/fb0
 r_dir_rw_file(hal_graphics_composer_default, sysfs_graphics)
+# Access /mnt/vendor/persist/display
+allow hal_graphics_composer_default mnt_vendor_file:dir search;
+r_dir_file(hal_graphics_composer_default, persist_display_file)
 
 # HWC_UeventThread
 allow hal_graphics_composer_default self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -1,13 +1,12 @@
+# Connect to the allocator:
 hal_client_domain(hal_graphics_composer_default, hal_graphics_allocator)
 
 # Binder access (for display.qservice)
 vndbinder_use(hal_graphics_composer_default)
 
-binder_call(hal_graphics_composer_default, hal_graphics_allocator_default)
-
+# HWC hosts the qdisplay and display config services:
 add_service(hal_graphics_composer_default, qdisplay_service)
 add_hwservice(hal_graphics_composer_default, hal_display_config_hwservice)
-allow hal_graphics_composer_default hal_graphics_allocator_hwservice:hwservice_manager find;
 
 allow hal_graphics_composer_default { graphics_device video_device }:chr_file rw_file_perms;
 


### PR DESCRIPTION
The graphics and audio HAL are already part of the allocator and power manager client domain, respectively. There is no need to grant them the `find` and `call` rights again.

Also address a denial regarding reading `/mnt/vendor/persist/display`.