### PR TITLE
[WIP] v7 Quick Fixes: rild prop name, netmgrd, cameraserver, audioserver, legacy /system

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -18,3 +18,5 @@
   execute system files
 - b/idc-kl: Remove vendor_idc_file and vendor_keylayout_file labels as they are
   labeled by AOSP already in Q
+- b/compatible: Remove all not_compatible_property() macros and update labels
+  once all devices use "compatible" props

--- a/BUGSs.md
+++ b/BUGSs.md
@@ -20,3 +20,5 @@
   labeled by AOSP already in Q
 - b/compatible: Remove all not_compatible_property() macros and update labels
   once all devices use "compatible" props
+- b/core-sp-hal: Remove sp-hal file labels once audioserver/cameraserver and
+  their associated libs no longer access vendor files

--- a/vendor/cameraserver.te
+++ b/vendor/cameraserver.te
@@ -1,4 +1,7 @@
-allow cameraserver gpu_device:chr_file rw_file_perms;
+set_prop(cameraserver, vendor_camera_prop)
 
 allow cameraserver system_server:unix_stream_socket { read write };
-set_prop(cameraserver, vendor_camera_prop)
+
+allow cameraserver device:dir { open read };
+allow cameraserver gpu_device:chr_file rw_file_perms;
+allow cameraserver video_device:chr_file { ioctl open read write };

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -168,6 +168,19 @@
 /(system/vendor|vendor|odm)/lib(64)?/libaptX_encoder\.so              u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libaptXHD_encoder\.so            u:object_r:same_process_hal_file:s0
 
+# Libs in /vendor/lib/hw/
+# TODO(b/core-sp-hal): Remove once audioserver and its associated libs no longer access vendor
+# files
+/(system/vendor|vendor)/lib(64)?/hw/android\.hardware\.audio@4\.0-impl\.so              u:object_r:same_process_hal_file:s0
+# TODO(b/core-sp-hal): Remove once cameraserver and its associated libs no longer access
+# vendor files
+/(system/vendor|vendor)/lib(64)?/hw/android\.hardware\.camera\.provider@2\.4-impl\.so   u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/camera\.device@1\.0-impl\.so                           u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/camera\.device@3\.2-impl\.so                           u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/camera\.device@3\.3-impl\.so                           u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/camera\.device@3\.4-impl\.so                           u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/camera\.device@3\.4-external-impl\.so                  u:object_r:same_process_hal_file:s0
+
 # data files
 /data/vendor/audio(/.*)?               u:object_r:audio_vendor_data_file:s0
 /data/vendor/bluetooth(/.*)?           u:object_r:bluetooth_vendor_data_file:s0

--- a/vendor/keystore.te
+++ b/vendor/keystore.te
@@ -1,0 +1,2 @@
+# Legacy keystore for tone and loire
+allow keystore system_file:dir { open read };

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -28,7 +28,7 @@ allow netmgrd self:capability {
     setuid
 };
 
-set_prop(netmgrd, net_radio_prop)
+set_prop(netmgrd, vendor_net_prop)
 set_prop(netmgrd, net_rmnet_prop)
 get_prop(netmgrd, hwservicemanager_prop)
 

--- a/vendor/property.te
+++ b/vendor/property.te
@@ -10,6 +10,7 @@ type timekeep_prop, property_type;
 type vendor_bluetooth_prop, property_type;
 type vendor_camera_prop, property_type;
 type vendor_device_prop, property_type;
+type vendor_net_prop, property_type;
 type vendor_peripheral_prop, property_type;
 type vendor_powerhal_prop, property_type;
 type vendor_radio_prop, property_type;

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -3,12 +3,12 @@ net.r_rmnet_data0               u:object_r:net_rmnet_prop:s0
 persist.camera.                 u:object_r:camera_prop:s0
 persist.cash.                   u:object_r:vendor_camera_prop:s0
 persist.dispcal.setting         u:object_r:dispcal_prop:s0
-persist.net.doxlat              u:object_r:net_radio_prop:s0
 persist.sys.timeadjust          u:object_r:timekeep_prop:s0
 persist.vendor.bluetooth.       u:object_r:vendor_bluetooth_prop:s0
 persist.vendor.bt.              u:object_r:vendor_bluetooth_prop:s0
 persist.vendor.camera.          u:object_r:vendor_camera_prop:s0
 persist.vendor.ims.             u:object_r:qcom_ims_prop:s0
+persist.vendor.net.             u:object_r:vendor_net_prop:s0
 persist.vendor.powerhal.        u:object_r:vendor_powerhal_prop:s0
 persist.vendor.radio.           u:object_r:vendor_radio_prop:s0
 persist.vendor.service.bdroid.  u:object_r:vendor_bluetooth_prop:s0

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -14,6 +14,8 @@ persist.vendor.radio.           u:object_r:vendor_radio_prop:s0
 persist.vendor.service.bdroid.  u:object_r:vendor_bluetooth_prop:s0
 persist.vendor.usb.             u:object_r:vendor_usb_prop:s0
 persist.vendor.usb.config       u:object_r:vendor_usb_config_prop:s0
+rild.                           u:object_r:radio_prop:s0
+vendor.rild.                    u:object_r:vendor_radio_prop:s0
 ro.vendor.bt.                   u:object_r:vendor_bluetooth_prop:s0
 ro.vendor.ril.                  u:object_r:vendor_radio_prop:s0
 ro.wifi.                        u:object_r:vendor_wifi_prop:s0

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -5,6 +5,11 @@ binder_call(rild, qcrilam_app);
 
 allow rild per_mgr_service:service_manager find;
 
+not_compatible_property(`
+  set_prop(rild, radio_prop)
+')
+set_prop(rild, vendor_radio_prop)
+
 allow rild radio_vendor_data_file:dir create_dir_perms;
 allow rild radio_vendor_data_file:file create_file_perms;
 
@@ -20,8 +25,6 @@ unix_socket_connect(rild, netmgrd, netmgrd)
 
 add_hwservice(rild, vnd_ims_radio_hwservice)
 add_hwservice(rild, vnd_qcrilhook_hwservice)
-
-set_prop(rild, vendor_radio_prop)
 
 allow rild self:socket ioctl;
 allowxperm rild self:socket ioctl msm_sock_ipc_ioctls;

--- a/vendor/thermalserviced.te
+++ b/vendor/thermalserviced.te
@@ -1,0 +1,1 @@
+allow thermalserviced system_file:dir { open read };

--- a/vendor/usbd.te
+++ b/vendor/usbd.te
@@ -1,0 +1,1 @@
+allow usbd system_file:dir { open read };

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -1,5 +1,13 @@
 typeattribute vendor_init data_between_core_and_vendor_violators;
 
+# TODO(b/compatible): Remove once all devices use compatible props
+# Get vendor.rild.rilpath
+get_prop(vendor_init, vendor_radio_prop)
+# Set rild.rilpath
+not_compatible_property(`
+  set_prop(vendor_init, radio_prop)
+')
+
 allow vendor_init {
     audio_data_file
     bluetooth_data_file


### PR DESCRIPTION
- Label `rild.*` and `vendor.rild.*` props and allow access
- Update label for `persist.net.doxlat`; the prop is renamed in `netmgrd` for v7 Software Binaries.
  Also stop using the `net_radio_prop` coredomain label for a vendor prop.
- Label camera and audio libs as sp-hal
  Ideally, `audioserver` and `cameraserver` should not access vendor files at all, but until that is fixed, label the hw libs as `same_process_hal` so that both system and vendor programs have access.
- `cameraserver`: Access `video_device`
- Allow searching `/system` dirs to some coredomains: `keystore`, `thermalserviced` and `usbd` are legacy domains which seem to be using wrong modes for searching system files.