### PR TITLE
tee: Label /data/misc/egistec and grant tee access.

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -73,6 +73,8 @@ type sensors_vendor_data_file, file_type, data_file_type;
 type timekeep_vendor_data_file, file_type, data_file_type;
 type wifi_vendor_data_file, file_type, data_file_type;
 
+type egistec_misc_data_file, file_type, data_file_type, core_data_file_type;
+
 # Input files in /vendor/usr/
 # TODO(b/idc-kl): These are labeled by AOSP already in Q
 type vendor_idc_file, file_type, vendor_file_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -182,6 +182,9 @@
 /data/vendor/time(/.*)?                u:object_r:timekeep_vendor_data_file:s0
 /data/vendor/wifi(/.*)?                u:object_r:wifi_vendor_data_file:s0
 
+# Misc data files (WARNING: violates core<->vendor boundaries)
+/data/misc/egistec(/.*)?               u:object_r:egistec_misc_data_file:s0
+
 # TODO: Remove them once no need to maintain the backward compatibility. (b/111219177)
 /persist                             u:object_r:rootfs:s0
 /firmware                            u:object_r:rootfs:s0

--- a/vendor/tee.te
+++ b/vendor/tee.te
@@ -22,6 +22,9 @@ typeattribute tee data_between_core_and_vendor_violators;
 allow tee system_data_file:dir r_dir_perms;
 allow tee fingerprintd_data_file:dir rw_dir_perms;
 allow tee fingerprintd_data_file:file create_file_perms;
+# Access /data/misc/egistec (Also a core<->vendor data violator):
+allow tee egistec_misc_data_file:dir rw_dir_perms;
+allow tee egistec_misc_data_file:file create_file_perms;
 
 # Create folders in /data/* and automatically label them
 type_transition tee system_data_file:{ dir file } tee_data_file;


### PR DESCRIPTION
This change allows Egistec fingerprint sensors to be used with enforcing sepolicy.

Tested on Discovery with full treble and split-sepolicy enabled.