### PR TITLE
[WIP] Remove dupe domain_auto_trans for netutils_wrapper

### DIFF
--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -9,9 +9,6 @@ not_full_treble(`
 net_domain(netmgrd)
 init_daemon_domain(netmgrd)
 
-# Allow netutils usage
-domain_auto_trans(netmgrd, netutils_wrapper_exec, netutils_wrapper)
-
 hwbinder_use(netmgrd)
 binder_call(netmgrd, netd)
 


### PR DESCRIPTION
AOSP sepolicy has this since 2017:

`netutils_wrapper.te`
```
domain_auto_trans({
    domain -coredomain -appdomain
}, netutils_wrapper_exec, netutils_wrapper)
```