### PR TITLE
hal_bluetooth_default: Allow opening diag_device in userdebug/eng.

### DIFF
--- a/vendor/hal_bluetooth_default.te
+++ b/vendor/hal_bluetooth_default.te
@@ -1,10 +1,10 @@
 allow hal_bluetooth_default bt_device:chr_file rw_file_perms;
 allow hal_bluetooth_default serial_device:chr_file rw_file_perms;
 userdebug_or_eng(`
-  allow hal_bluetooth_default diag_device:chr_file { read write };
+  allow hal_bluetooth_default diag_device:chr_file rw_file_perms;
 ')
 # Ignore in user builds
-dontaudit hal_bluetooth_default diag_device:chr_file { read write };
+dontaudit hal_bluetooth_default diag_device:chr_file rw_file_perms;
 
 allow hal_bluetooth_default bluetooth_vendor_data_file:dir create_dir_perms;
 allow hal_bluetooth_default bluetooth_vendor_data_file:file create_file_perms;


### PR DESCRIPTION
In order to read or write to /dev/diag, the file needs to be opened in
the first place. Use rw_file_perms to simplify the access.

Adresses:
W bluetooth@1.0-s: type=1400 audit(0.0:71): avc: denied { open } for path="/dev/diag" dev="tmpfs" ino=17553 scontext=u:r:hal_bluetooth_default:s0 tcontext=u:object_r:diag_device:s0 tclass=chr_file
E Diag_Lib:  Diag_LSM_Init: Failed to open handle to diag driver, error = 13
E vendor.qti.bluetooth@1.0-diag_interface: Failed to Init diag
E Diag_Lib: diag: In diagpkt_tbl_reg, service not initialized.

NOTE: Even though the HAL "says" it initializes fine in the logs, it
actually fails later on, leaving Bluetooth dysfunctional. In turn, the
system counterpart crashes for not being able to locate the service.