### PR TITLE
sepolicy: avoid netutils_wrapper denials

### DIFF
--- a/vendor/netutils_wrapper.te
+++ b/vendor/netutils_wrapper.te
@@ -3,9 +3,11 @@ allow netutils_wrapper netmgrd:fd use;
 allow netutils_wrapper netmgrd:fifo_file { getattr read write append };
 allow netutils_wrapper netmgrd:file r_file_perms;
 
+allow netutils_wrapper sysfs_soc:file read;
+allow netutils_wrapper diag_device:chr_file { read write };
+
 dontaudit netutils_wrapper netmgrd:socket { read write };
 dontaudit netutils_wrapper netmgrd:unix_stream_socket { read write };
 dontaudit netutils_wrapper netmgrd:netlink_socket { getattr read write append };
 dontaudit netutils_wrapper kernel:system module_request;
 dontaudit netutils_wrapper self:capability sys_module;
-allow netutils_wrapper sysfs_soc:file read;


### PR DESCRIPTION
04-12 01:32:52.659  5031  5031 I tc-wrapper-1.0: type=1400 audit(0.0:979): avc: denied { read write } for path=/dev/diag dev=tmpfs ino=18528 scontext=u:r:netutils_wrapper:s0 tcontext=u:object_r:diag_device:s0 tclass=chr_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>