### PR TITLE
system_app: Allow creating netlink sockets

### DIFF
--- a/vendor/system_app.te
+++ b/vendor/system_app.te
@@ -25,6 +25,8 @@ binder_call(system_app, update_engine)
 # This is a neverallow anyways, so ignore it
 dontaudit system_app perfprofd:binder call;
 
+allow system_app self:netlink_kobject_uevent_socket { bind create read setopt };
+
 allow system_app fs_bpf:dir search;
 allow system_app proc_pagetypeinfo:file r_file_perms;
 allow system_app sysfs_zram:dir search;


### PR DESCRIPTION
Denials:
```
avc: denied { bind } for comm="UEventObserver" scontext=u:r:system_app:s0 \
  tcontext=u:r:system_app:s0 tclass=netlink_kobject_uevent_socket
avc: denied { create } for comm="UEventObserver" scontext=u:r:system_app:s0 \
  tcontext=u:r:system_app:s0 tclass=netlink_kobject_uevent_socket
avc: denied { read } for comm="UEventObserver" scontext=u:r:system_app:s0 \
  tcontext=u:r:system_app:s0 tclass=netlink_kobject_uevent_socket
avc: denied { setopt } for comm="UEventObserver" scontext=u:r:system_app:s0 \
  tcontext=u:r:system_app:s0 tclass=netlink_kobject_uevent_socket
```