### PR TITLE
Kernel sockets for user/-debug

### DIFF
--- a/vendor/kernel.te
+++ b/vendor/kernel.te
@@ -1,7 +1,9 @@
-# for diag over socket
 userdebug_or_eng(`
+  # for diag over socket
   allow kernel self:socket create;
 ')
+# Ignore in user builds
+dontaudit kernel self:socket create;
 
 dontaudit kernel kernel:system module_request;
 

--- a/vendor/kernel.te
+++ b/vendor/kernel.te
@@ -1,12 +1,13 @@
 userdebug_or_eng(`
   # for diag over socket
   allow kernel self:socket create;
+  # A kernel worker has to read from /d/wlan{,0}/,
+  # otherwise debug files are not created there.
+  r_dir_file(kernel, debugfs_wlan)
 ')
 # Ignore in user builds
 dontaudit kernel self:socket create;
 
 dontaudit kernel kernel:system module_request;
-
-# A kernel worker has to read from /d/wlan{,0}/,
-# otherwise debug files are not created there.
-r_dir_file(kernel, debugfs_wlan)
+dontaudit kernel debugfs_wlan:dir r_dir_perms;
+dontaudit kernel debugfs_wlan:file r_file_perms;


### PR DESCRIPTION
Diag and wlan debugging stuff is only needed in `userdebug` builds

`avc: denied { create } for comm="kworker/u8:2" scontext=u:r:kernel:s0 tcontext=u:r:kernel:s0 tclass=socket`