### PR TITLE
[WIP] addrsetup: Ignore kernel module request

### DIFF
--- a/vendor/addrsetup.te
+++ b/vendor/addrsetup.te
@@ -23,3 +23,5 @@ allow addrsetup self:capability { net_admin net_raw };
 allow addrsetup self:udp_socket { create ioctl };
 # If compiled with BRCFMAC:
 allowxperm addrsetup self:udp_socket ioctl SIOCSIFHWADDR;
+
+dontaudit addrsetup kernel:system module_request;


### PR DESCRIPTION
macaddrsetup works fine without loading kernel modules

Denial:
`avc: denied { module_request } for comm="macaddrsetup" kmod="netdev-wlan0" context=u:r:addrsetup:s0 tcontext=u:r:kernel:s0 tclass=system`