### PR TITLE
netutils: Remove unused legacy access

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -13,9 +13,6 @@
 - b/77868789: netd tethering: Remove once fixed upstream
 - b/867711: webview_zygote: Fix socket call to parent in code
 - b/124102550: system_server: Remove once fixed upstream
-- b/netutils-lock: Remove lock on xtables.lock once netutils wrappers are available
-- b/netmgrd-system: Remove system file access once netmgrd does no longer
-  execute system files
 - b/idc-kl: Remove vendor_idc_file and vendor_keylayout_file labels as they are
   labeled by AOSP already in Q
 - b/compatible: Remove all not_compatible_property() macros and update labels

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -1,10 +1,5 @@
 type netmgrd, domain;
 type netmgrd_exec, exec_type, vendor_file_type, file_type;
-# TODO(b/netmgrd-system): Remove this once netutils does not
-# execute system files,
-not_full_treble(`
-  typeattribute netmgrd vendor_executes_system_violators;
-')
 
 net_domain(netmgrd)
 init_daemon_domain(netmgrd)
@@ -66,20 +61,6 @@ allow netmgrd proc_net:file rw_file_perms;
 
 allow netmgrd netmgr_vendor_data_file:dir rw_dir_perms;
 allow netmgrd netmgr_vendor_data_file:file create_file_perms;
-
-# Allow execution of commands in shell
-# TODO(b/netmgrd-system): Remove this once netmgrd does not execute
-# system files, it's a neverallow on Q without
-# vendor_executes_system_violators
-not_full_treble(`
-  allow netmgrd system_file:file x_file_perms;
-')
-
-# Acquire lock on /system/etc/xtables.lock
-# TODO(b/netutils-lock): Required till netutils wrappers are available
-not_full_treble(`
-  allow netmgrd system_file:file lock;
-')
 
 allow netmgrd vendor_toolbox_exec:file rx_file_perms;
 


### PR DESCRIPTION
Since device-sony-common@a321b9 sepolicy is compiled with
`PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true`

That means the content of `not_full_treble()` macros is ignored.