### PR TITLE
[WIP] Add policy for restorecon service

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -85,6 +85,7 @@
 /(system/vendor|vendor)/bin/init\.qcom\.adspstart\.sh                                        u:object_r:init-qcom-adspstart-sh_exec:s0
 /(system/vendor|vendor)/bin/init\.qcom\.cdspstart\.sh                                        u:object_r:init-qcom-cdspstart-sh_exec:s0
 /(system/vendor|vendor)/bin/init\.qcom\.ipastart\.sh                                         u:object_r:init-qcom-ipastart-sh_exec:s0
+/(system/vendor|vendor)/bin/restorecon_persist\.sh                                           u:object_r:restorecon_persist_exec:s0
 /(system/vendor|vendor)/bin/initlight                                                        u:object_r:initlight_exec:s0
 /(system/vendor|vendor)/bin/ipacm                                                            u:object_r:hal_tetheroffload_default_exec:s0
 /(system/vendor|vendor)/bin/ucommsvr                                                         u:object_r:ucommsvr_exec:s0

--- a/vendor/restorecon_persist.te
+++ b/vendor/restorecon_persist.te
@@ -1,0 +1,9 @@
+type restorecon_persist, domain;
+type restorecon_persist_exec, exec_type, vendor_file_type, file_type;
+
+init_daemon_domain(restorecon_persist)
+
+# Clear security.restorecon_last xattr from /mnt/vendor/persist/sensors/
+allow restorecon_persist persist_file:dir setattr;
+# Execute /vendor/bin/toybox_vendor
+allow restorecon_persist vendor_toolbox_exec:file execute_no_trans;

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -38,4 +38,7 @@ allow vendor_init persist_file:lnk_file read;
 # Create and chown /(mnt/vendor/)persist/battery/ folder for health HAL
 allow vendor_init persist_battery_file:dir create_dir_perms;
 
+# Relabel /mnt/vendor/persist/ files
+allow vendor_init unlabeled:dir { getattr relabelfrom };
+
 allow vendor_init device:file { create write };


### PR DESCRIPTION
Add labels for `vendor.restorecon_persist` script so that it can wipe `security.restorecon_last` xattrs.

Also allow `vendor_init` to re-label stock files inside `/persist`.

See also https://github.com/sonyxperiadev/device-sony-common/pull/600/files