### PR TITLE
[WIP] vendor_init: Fix /mnt/vendor/persist/ labels

### DIFF
--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -38,4 +38,9 @@ allow vendor_init persist_file:lnk_file read;
 # Create and chown /(mnt/vendor/)persist/battery/ folder for health HAL
 allow vendor_init persist_battery_file:dir create_dir_perms;
 
+# Relabel /mnt/vendor/persist/ files
+allow vendor_init unlabeled:{ dir file } { getattr setattr relabelfrom };
+# Execute /vendor/bin/toybox_vendor
+allow vendor_init vendor_toolbox_exec:file execute_no_trans;
+
 allow vendor_init device:file { create write };


### PR DESCRIPTION
Policy for https://github.com/sonyxperiadev/device-sony-common/pull/601

Denials:
avc: denied { getattr } for comm="init" path="/mnt/vendor/persist/sensors" \
  dev="mmcblk0p44" ino=12 scontext=u:r:vendor_init:s0 \
  tcontext=u:object_r:unlabeled:s0 tclass=dir
avc: denied { relabelfrom } for comm="init" name="sensors" \
  dev="mmcblk0p44" ino=12 scontext=u:r:vendor_init:s0 \
  tcontext=u:object_r:unlabeled:s0 tclass=dir
avc: denied { getattr } for comm="init" \
  path="/mnt/vendor/persist/sensors/sensors_settings" dev="mmcblk0p44" \
  ino=13 scontext=u:r:vendor_init:s0 tcontext=u:object_r:unlabeled:s0 tclass=file
avc: denied { relabelfrom } for comm="init" name="sensors_settings" \
  dev="mmcblk0p44" ino=13 scontext=u:r:vendor_init:s0 \
  tcontext=u:object_r:unlabeled:s0 tclass=file