### PR TITLE
vendor_init: Allow entrypoint toybox_vendor

### DIFF
--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -41,6 +41,6 @@ allow vendor_init persist_battery_file:dir create_dir_perms;
 # Relabel /mnt/vendor/persist/ files
 allow vendor_init unlabeled:{ dir file } { getattr setattr relabelfrom };
 # Execute /vendor/bin/toybox_vendor
-allow vendor_init vendor_toolbox_exec:file execute_no_trans;
+allow vendor_init vendor_toolbox_exec:file { entrypoint execute_no_trans };
 
 allow vendor_init device:file { create write };


### PR DESCRIPTION
Denial:
avc: denied { entrypoint } for comm="init" \
  path="/system/vendor/bin/toybox_vendor" dev="mmcblk0p55" \
  ino=2639 scontext=u:r:vendor_init:s0 \
  tcontext=u:object_r:vendor_toolbox_exec:s0 tclass=file