### PR TITLE
[Q-COMPAT] Update toybox run context

### DIFF
--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -39,8 +39,6 @@ allow vendor_init persist_file:lnk_file read;
 allow vendor_init persist_battery_file:dir create_dir_perms;
 
 # Relabel /mnt/vendor/persist/ files
-allow vendor_init unlabeled:{ dir file } { getattr setattr relabelfrom };
-# Execute /vendor/bin/toybox_vendor
-allow vendor_init vendor_toolbox_exec:file { entrypoint execute_no_trans };
+allow vendor_init unlabeled:{ dir file } { getattr relabelfrom };
 
 allow vendor_init device:file { create write };

--- a/vendor/vendor_toolbox.te
+++ b/vendor/vendor_toolbox.te
@@ -2,3 +2,7 @@
 type vendor_toolbox, domain;
 
 init_daemon_domain(vendor_toolbox)
+
+# Remove "security.*" xattrs from /mnt/vendor/persist/
+allow vendor_toolbox mnt_vendor_file:dir search;
+allow vendor_toolbox { persist_file mnt_vendor_file }:dir { setattr };

--- a/vendor/vendor_toolbox.te
+++ b/vendor/vendor_toolbox.te
@@ -6,3 +6,5 @@ init_daemon_domain(vendor_toolbox)
 # Remove "security.*" xattrs from /mnt/vendor/persist/
 allow vendor_toolbox mnt_vendor_file:dir search;
 allow vendor_toolbox { persist_file mnt_vendor_file }:dir { setattr };
+
+allow vendor_toolbox self:global_capability_class_set sys_admin;

--- a/vendor/vendor_toolbox.te
+++ b/vendor/vendor_toolbox.te
@@ -1,0 +1,4 @@
+# /vendor/bin/(toybox_vendor|toolbox)
+type vendor_toolbox, domain;
+
+init_daemon_domain(vendor_toolbox)


### PR DESCRIPTION
(Accompanies https://github.com/sonyxperiadev/device-sony-common/pull/613)

### Add vendor_toolbox context
Certain commands from the vendor toybox located at `/vendor/bin/toybox_vendor` may be executed directly by our vendor init.

### vendor_toolbox: Allow removing xattr from /persist
The exec for `toybox_vendor setfattr` was moved from the `vendor_init` to the `vendor_toolbox` context.

### vendor_init: Strip unneeded toybox-related permissions
Since the exec statement for the `toybox_vendor setfattr` operation was moved into the `vendor_toolbox` context, `vendor_init` needs less permissions.