### PR TITLE
[3/4] Allow ExtendedSettings (system_app) to read sysfs_glove_mode.

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -7,6 +7,7 @@ type sysfs_console_suspend, sysfs_type, fs_type;
 type sysfs_diag, fs_type, sysfs_type;
 type sysfs_esoc, sysfs_type, fs_type;
 type sysfs_fingerprint, sysfs_type, fs_type;
+type sysfs_glove_mode, sysfs_type, fs_type;
 type sysfs_graphics, sysfs_type, fs_type;
 type sysfs_input_control, sysfs_type, fs_type;
 type sysfs_input_name, sysfs_type, fs_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -117,6 +117,10 @@
 /sys/class/rtc(/.*)?                                                                         u:object_r:sysfs_rtc:s0
 # Disk schedulers
 /sys/block/[^/]+/queue(/.*)?                                                                 u:object_r:sysfs_block_queue:s0
+# Glove mode:
+# Clearpad: /sys/devices/virtual/input/clearpad/glove:
+/sys/devices/virtual/input/input[0-9]+/glove                                                 u:object_r:sysfs_glove_mode:s0
+/sys/devices/virtual/input/lge_touch/glove_mode                                              u:object_r:sysfs_glove_mode:s0
 
 ###############################################
 # same-process HAL files and their dependencies

--- a/vendor/system_app.te
+++ b/vendor/system_app.te
@@ -8,6 +8,7 @@ typeattribute system_app system_writes_vendor_properties_violators;
 r_dir_file(system_app, selinuxfs)
 
 # ExtendedSettings props
+r_dir_rw_file(system_app, sysfs_glove_mode)
 r_dir_rw_file(system_app, sysfs_graphics)
 r_dir_rw_file(system_app, sysfs_pcc_profile)
 set_prop(system_app, vendor_adbtcpes_prop)


### PR DESCRIPTION
For https://github.com/sonyxperiadev/packages_apps_ExtendedSettings/pull/49.