### PR TITLE
[2/7] hal_fingerprint_default: Allow emitting events to uinput.

### DIFF
--- a/vendor/hal_fingerprint_default.te
+++ b/vendor/hal_fingerprint_default.te
@@ -4,6 +4,7 @@ r_dir_rw_file(hal_fingerprint_default, sysfs_fingerprint)
 allow hal_fingerprint_default tee_device:file rw_file_perms;
 allow hal_fingerprint_default tee_device:chr_file rw_file_perms;
 allow hal_fingerprint_default fingerprint_device:chr_file rw_file_perms;
+allow hal_fingerprint_default uhid_device:chr_file { ioctl w_file_perms };
 
 # TODO(b/36644492): Remove data_between_core_and_vendor_violators once
 # hal_fingerprint no longer directly accesses fingerprintd_data_file.


### PR DESCRIPTION
For https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/50

Now that we can get the sensor to detect swipe gestures, allow the HAL to send the "generated keycodes" to the system through uinput.
