### PR TITLE
[WIP] nfc: Allow reading /vendor/etc/libnfc-nci.conf

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -79,6 +79,7 @@
 # TODO(b/idc-kl): These are labeled by AOSP already in Q
 /(system/vendor|vendor)/usr/idc(/.*)?                                                        u:object_r:vendor_idc_file:s0
 /(system/vendor|vendor)/usr/keylayout(/.*)?                                                  u:object_r:vendor_keylayout_file:s0
+/(system/vendor|vendor)/etc/libnfc-nci.conf                                                  u:object_r:vendor_configs_file:s0
 /(system/vendor|vendor)/bin/macaddrsetup                                                     u:object_r:addrsetup_exec:s0
 /(system/vendor|vendor)/bin/rdclean\.sh                                                      u:object_r:rdclean_exec:s0
 /(system/vendor|vendor)/bin/init\.qcom\.slpistart\.sh                                        u:object_r:init-qcom-slpistart-sh_exec:s0

--- a/vendor/nfc.te
+++ b/vendor/nfc.te
@@ -1,3 +1,6 @@
 # Data file accesses.
 allow nfc nfc_vendor_data_file:dir create_dir_perms;
 allow nfc nfc_vendor_data_file:file create_file_perms;
+
+# Read /vendor/etc/libnfc-nci.conf
+allow nfc vendor_configs_file:file r_file_perms;


### PR DESCRIPTION
With the move of the config file in https://github.com/sonyxperiadev/device-sony-tone/pull/1752 to `/vendor/etc` for tone (and soon the other platforms), `nfc` needs access to the new file location.