### PR TITLE
[2/2] [WIP] health: Storage stats

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -13,6 +13,7 @@ type sysfs_input_control, sysfs_type, fs_type;
 type sysfs_input_name, sysfs_type, fs_type;
 type sysfs_irq, sysfs_type, fs_type;
 type sysfs_mdss_mdp_caps, sysfs_type, fs_type;
+type sysfs_mmc, sysfs_type, fs_type;
 type sysfs_msm_subsys, sysfs_type, fs_type;
 type sysfs_msm_subsys_restart, sysfs_type, fs_type;
 type sysfs_pcc_profile, sysfs_type, fs_type;

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -56,6 +56,9 @@ genfscon sysfs /devices/platform/soc/soc:qcom,kgsl-hyp                  u:object
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws@1e08000           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/0.qcom,rmtfs_sharedmem             u:object_r:sysfs_rmtfs:s0
 
+genfscon sysfs /block/mmcblk0                                           u:object_r:sysfs_mmc:s0
+genfscon sysfs /bus/mmc/devices/mmc0:0001                               u:object_r:sysfs_mmc:s0
+
 genfscon sysfs /module/diagchar                                         u:object_r:sysfs_diag:s0
 genfscon sysfs /kernel/irq_helper/irq_blacklist_on                      u:object_r:sysfs_irq:s0
 genfscon sysfs /kernel/boot_wlan/boot_wlan                              u:object_r:sysfs_boot_wlan:s0

--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -14,3 +14,6 @@ allow hal_health_default { sysfs_msm_subsys persist_file }:dir search;
 allow hal_health_default sysfs_usb_supply:file r_file_perms;
 # Read or restore battery statistics
 allow hal_health_default sysfs_batteryinfo:file rw_file_perms;
+# Read storage stats and emmc health
+allow hal_health_default sysfs_mmc:dir search;
+allow hal_health_default sysfs_mmc:file r_file_perms;

--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -17,3 +17,8 @@ allow hal_health_default sysfs_batteryinfo:file rw_file_perms;
 # Read storage stats and emmc health
 allow hal_health_default sysfs_mmc:dir search;
 allow hal_health_default sysfs_mmc:file r_file_perms;
+
+# Read persist.vendor.health.fake_storage for debugging
+userdebug_or_eng(`
+  get_prop(hal_health_default, vendor_health_prop)
+')

--- a/vendor/property.te
+++ b/vendor/property.te
@@ -10,6 +10,7 @@ type vendor_camera_prop, property_type;
 type vendor_cash_prop, property_type;
 type vendor_device_prop, property_type;
 type vendor_dispcal_prop, property_type;
+type vendor_health_prop, property_type;
 type vendor_keymaster_prop, property_type;
 type vendor_net_prop, property_type;
 type vendor_peripheral_prop, property_type;

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -5,6 +5,7 @@ persist.vendor.bt.              u:object_r:vendor_bluetooth_prop:s0
 persist.vendor.camera.          u:object_r:vendor_camera_prop:s0
 persist.vendor.cash.            u:object_r:vendor_cash_prop:s0
 persist.vendor.dispcal.         u:object_r:vendor_dispcal_prop:s0
+persist.vendor.health.          u:object_r:vendor_health_prop:s0
 persist.vendor.ims.             u:object_r:qcom_ims_prop:s0
 persist.vendor.net.             u:object_r:vendor_net_prop:s0
 persist.vendor.powerhal.        u:object_r:vendor_powerhal_prop:s0

--- a/vendor/shell.te
+++ b/vendor/shell.te
@@ -6,6 +6,8 @@ typeattribute shell system_writes_vendor_properties_violators;
 # Allow non-root to tune powerhal and CASH
 set_prop(shell, vendor_powerhal_prop)
 set_prop(shell, vendor_cash_prop)
+# Set persist.vendor.health.fake_storage for debugging
+set_prop(shell, vendor_health_prop)
 
 # To allow non-root to find power_supply management info
 allow shell sysfs_msm_subsys:dir search;

--- a/vendor/vold.te
+++ b/vendor/vold.te
@@ -9,6 +9,11 @@ allow vold {
       persist_block_device
 }:blk_file getattr;
 
+# Vold would have access to /sys/block/mmcblk0 because it can
+# access all of u:r:sysfs:s0. But since we have labeled the
+# mmc nodes differently, vold needs access to the new labels:
+allow vold sysfs_mmc:file w_file_perms;
+
 # Load crypto modules
 allow vold kernel:system module_request;
 


### PR DESCRIPTION
Accompanies https://github.com/sonyxperiadev/device-sony-common/pull/628

### Label MMC sysfs paths

### health: Allow reading MMC storage stats

### vold: Access new sysfs_mmc label

Vold would have access to /sys/block/mmcblk0 because it can access all of u:r:sysfs:s0. But since we have labeled the mmc nodes differently, vold needs access to the new labels:

### health: Allow debugging HAL via prop 