### PR TITLE
[Q-COMPAT] system_app: Remove obsolete perfprofd dontaudit

### DIFF
--- a/vendor/system_app.te
+++ b/vendor/system_app.te
@@ -23,9 +23,6 @@ binder_call(system_app, per_mgr)
 binder_call(system_app, wificond)
 binder_call(system_app, update_engine)
 
-# This is a neverallow anyways, so ignore it
-dontaudit system_app perfprofd:binder call;
-
 allow system_app self:netlink_kobject_uevent_socket { bind create read setopt };
 
 allow system_app fs_bpf:dir search;


### PR DESCRIPTION
Q removes `perfprofd` entirely and including the `dontaudit` will throw an error when compiling with current master branch.