### PR TITLE
avoid wifi denials

### DIFF
--- a/vendor/hal_wifi_default.te
+++ b/vendor/hal_wifi_default.te
@@ -4,3 +4,4 @@ allow hal_wifi_default sysfs_boot_wlan:file w_file_perms;
 r_dir_file(hal_wifi_default, debugfs_wlan)
 
 allow hal_wifi_default kernel:system module_request;
+allow hal_wifi_default tombstone_wifi_data_file:dir r_dir_perms;


### PR DESCRIPTION
08-15 15:15:31.177   684   684 W wifi@1.0-servic: type=1400 audit(0.0:5): avc: denied { read } for name=wifi dev=mmcblk0p73 ino=786436 scontext=u:r:hal_wifi_default:s0 tcontext=u:object_r:tombstone_wifi_data_file:s0 tclass=dir permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>