### PR TITLE
firmware_file GSI compat

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -23,3 +23,4 @@
   Android R
 - b/qcrild: Remove qcrild_exec label and rild domain transition when odm-v5 is
   released
+- b/36764215: Remove `firmware_file` compat once 64bit A/B GSIs stop shipping it

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -51,6 +51,11 @@ type ucommsvr_socket, file_type;
 
 type vendor_firmware_file, file_type, vendor_file_type, contextmount_type;
 
+# TODO(b/36764215): remove this file when the generic system image
+# no longer has these directories. They are specific to QCOM.
+# Default type for anything under /firmware.
+type firmware_file, fs_type, contextmount_type;
+
 type persist_file, file_type, vendor_persist_type;
 type persist_alarm_file, file_type, vendor_persist_type;
 type persist_battery_file, file_type, vendor_persist_type;

--- a/vendor/hal_fingerprint_default.te
+++ b/vendor/hal_fingerprint_default.te
@@ -1,6 +1,10 @@
 r_dir_file(hal_fingerprint_default, vendor_firmware_file)
 r_dir_rw_file(hal_fingerprint_default, sysfs_fingerprint)
 
+# TODO(b/36764215): remove this file when the generic system image
+# no longer has these directories. They are specific to QCOM.
+r_dir_file(hal_fingerprint_default, firmware_file)
+
 allow hal_fingerprint_default tee_device:file rw_file_perms;
 allow hal_fingerprint_default tee_device:chr_file rw_file_perms;
 allow hal_fingerprint_default fingerprint_device:chr_file rw_file_perms;

--- a/vendor/ueventd.te
+++ b/vendor/ueventd.te
@@ -5,6 +5,7 @@ typeattribute ueventd data_between_core_and_vendor_violators;
 r_dir_file(ueventd, vendor_firmware_file)
 r_dir_file(ueventd, persist_file)
 r_dir_file(ueventd, wifi_vendor_data_file)
+allow ueventd firmware_file:lnk_file read;
 
 allow ueventd {
     { sysfs_type - usermodehelper }


### PR DESCRIPTION
This is needed because 64bit A/B GSIs use these labels in /system_root because of ...some legacy qcom reasons.

See https://android.googlesource.com/platform/build/+/refs/tags/android-9.0.0_r47/target/board/generic_arm64_ab/sepolicy/file_contexts

(We have our own label `u:object_r:rootfs:s0` for `/firmware` already, but with system-as-root, the `/firmware` symlink resides inside the GSI and we thus cannot change the label.)

Denials:
```
QSEECOMAPI: Error::Cannot open the file \
  /firmware/image/egisap32.mdt errno = 13
QSEECOMAPI: Error::Loading image failed with ret = -1
android.hardwar: type=1400 audit(0.0:95): avc: denied { search } \
  for name="firmware" dev="dm-0" ino=4347 \
  scontext=u:r:hal_fingerprint_default:s0 \
  tcontext=u:object_r:unlabeled:s0 tclass=dir
```