### PR TITLE
[VERIFYME] Label and access /sys/module/usb_f_mtp

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -15,6 +15,7 @@ type sysfs_irq, sysfs_type, fs_type;
 type sysfs_mdss_mdp_caps, sysfs_type, fs_type;
 type sysfs_msm_subsys, sysfs_type, fs_type;
 type sysfs_msm_subsys_restart, sysfs_type, fs_type;
+type sysfs_mtp, sysfs_type, fs_type;
 type sysfs_pcc_profile, sysfs_type, fs_type;
 type sysfs_rgbc_sensor, fs_type, sysfs_type;
 type sysfs_rmtfs, sysfs_type, fs_type;

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -49,6 +49,7 @@ genfscon sysfs /kernel/boot_adsp/boot                                   u:object
 genfscon sysfs /kernel/boot_cdsp/boot                                   u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /kernel/boot_slpi/boot                                   u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /module/msm_performance                                  u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /module/usb_f_mtp                                        u:object_r:sysfs_mtp:s0
 
 genfscon sysfs /devices/platform/soc/soc:bt_wcn3990                     u:object_r:sysfs_bluetooth_writable:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,gpubw                     u:object_r:sysfs_msm_subsys:s0

--- a/vendor/vendor_init.te
+++ b/vendor/vendor_init.te
@@ -34,6 +34,9 @@ allow vendor_init proc_kernel_printk:file write;
 # Set disk parameters
 allow vendor_init sysfs_block_queue:file { open setattr write };
 
+# Set MTP USB parameters
+rw_dir_file(vendor_init, sysfs_mtp)
+
 allow vendor_init persist_file:lnk_file read;
 # Create and chown /(mnt/vendor/)persist/battery/ folder for health HAL
 allow vendor_init persist_battery_file:dir create_dir_perms;


### PR DESCRIPTION
vendor init needs to write usb_f_mtp params to sysfs.

See https://github.com/sonyxperiadev/device-sony-tone/pull/184
https://github.com/sonyxperiadev/device-sony-loire/pull/253
See https://github.com/sonyxperiadev/bug_tracker/issues/432#issuecomment-517964636