### PR TITLE
tad/tee: Specify which ioctls are called on blk_file

### DIFF
--- a/vendor/tad.te
+++ b/vendor/tad.te
@@ -6,6 +6,7 @@ init_daemon_domain(tad)
 allow tad kernel:system module_request;
 allow tad block_device:dir { getattr search };
 allow tad ta_block_device:blk_file rw_file_perms;
+allowxperm tad ta_block_device:blk_file ioctl BLKGETSIZE;
 allow tad mnt_vendor_file:dir search;
 
 # Read access to pseudo filesystems.

--- a/vendor/tee.te
+++ b/vendor/tee.te
@@ -11,6 +11,7 @@ allow tee vendor_firmware_file:dir search;
 allow tee vendor_firmware_file:file r_file_perms;
 allow tee block_device:dir { getattr search };
 allow tee rpmb_block_device:blk_file rw_file_perms;
+allowxperm tee rpmb_block_device:blk_file ioctl MMC_IOC_CMD;
 allow tee ssd_block_device:blk_file rw_file_perms;
 allow tee sg_device:chr_file { rw_file_perms setattr };
 


### PR DESCRIPTION
On android Q, this is a requirement (though I cannot find where it changed, apart a `neverallowxperm` which doesn't change the situation).
Entering the device pincode will fail on startup (Mermaid) and Discovery fails to boot altogether without these.

There is no harm in adding these on Pie (in fact, pretty much all other ioctls are explicit already and no further denials show up).