### PR TITLE
[Android 10] Drop deprecated patches; remove superfluous versioning; bump HAl version.

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -13,8 +13,6 @@
 - b/77868789: netd tethering: Remove once fixed upstream
 - b/867711: webview_zygote: Fix socket call to parent in code
 - b/124102550: system_server: Remove once fixed upstream
-- b/idc-kl: Remove vendor_idc_file and vendor_keylayout_file labels as they are
-  labeled by AOSP already in Q
 - b/compatible: Remove all not_compatible_property() macros and update labels
   once all devices use "compatible" props
 - b/core-sp-hal: Remove sp-hal file labels once audioserver/cameraserver and

--- a/sepolicy.mk
+++ b/sepolicy.mk
@@ -7,7 +7,3 @@ BOARD_VENDOR_SEPOLICY_DIRS += \
 
 BOARD_PLAT_PRIVATE_SEPOLICY_DIR += \
     $(LOCAL_SEPOLICY)/private
-
-# Add sepolicy version to support OS upgrade and backward compatibility
-BOARD_SEPOLICY_VERS := \
-    $(PLATFORM_SDK_VERSION).0

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -81,11 +81,6 @@ type wifi_vendor_data_file, file_type, data_file_type;
 
 type egistec_misc_data_file, file_type, data_file_type, core_data_file_type;
 
-# Input files in /vendor/usr/
-# TODO(b/idc-kl): These are labeled by AOSP already in Q
-type vendor_idc_file, file_type, vendor_file_type;
-type vendor_keylayout_file, file_type, vendor_file_type;
-
 # Battery Stats file
 typeattribute sysfs_batteryinfo mlstrustedobject;
 

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -76,9 +76,6 @@
 # files in /vendor
 /(system/vendor|vendor)/rfs(/.*)?                                                            u:object_r:rfs_system_file:s0
 /(system/vendor|vendor)/firmware(/.*)?                                                       u:object_r:vendor_firmware_file:s0
-# TODO(b/idc-kl): These are labeled by AOSP already in Q
-/(system/vendor|vendor)/usr/idc(/.*)?                                                        u:object_r:vendor_idc_file:s0
-/(system/vendor|vendor)/usr/keylayout(/.*)?                                                  u:object_r:vendor_keylayout_file:s0
 /(system/vendor|vendor)/bin/macaddrsetup                                                     u:object_r:addrsetup_exec:s0
 /(system/vendor|vendor)/bin/rdclean\.sh                                                      u:object_r:rdclean_exec:s0
 /(system/vendor|vendor)/bin/init\.qcom\.slpistart\.sh                                        u:object_r:init-qcom-slpistart-sh_exec:s0
@@ -231,3 +228,7 @@
 /mnt/vendor/persist/secnvm(/.*)?               u:object_r:persist_secnvm_file:s0
 /mnt/vendor/persist/sensors(/.*)?              u:object_r:persist_sensors_file:s0
 /mnt/vendor/persist/time(/.*)?                 u:object_r:persist_time_file:s0
+
+# legacy system/vendor:
+/(system/)?vendor/usr/idc(/.*)?                u:object_r:vendor_idc_file:s0
+/(system/)?vendor/usr/keylayout(/.*)?          u:object_r:vendor_keylayout_file:s0

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -92,7 +92,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.bluetooth@1\.0-service-qti                 u:object_r:hal_bluetooth_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@1\.1-service-qti                      u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
-/(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.1-service\.clearkey                 u:object_r:hal_drm_clearkey_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.2-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health@2\.0-service\.sony                  u:object_r:hal_health_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.usb@1\.0-service\.basic                    u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -36,12 +36,10 @@ genfscon sysfs /class/thermal                                           u:object
 genfscon sysfs /devices/virtual/thermal                                 u:object_r:sysfs_thermal:s0
 genfscon sysfs /module/msm_thermal                                      u:object_r:sysfs_thermal:s0
 genfscon sysfs /module/printk/parameters/console_suspend                u:object_r:sysfs_console_suspend:s0
-genfscon sysfs /module/tcp_cubic/parameters                             u:object_r:sysfs_net:s0
 genfscon sysfs /module/diagchar/parameters/timestamp_switch             u:object_r:sysfs_timestamp_switch:s0
 genfscon sysfs /devices/virtual/graphics/fb0                            u:object_r:sysfs_graphics:s0
 genfscon sysfs /devices/virtual/graphics/fb1                            u:object_r:sysfs_graphics:s0
 genfscon sysfs /devices/virtual/graphics/fb2                            u:object_r:sysfs_graphics:s0
-genfscon sysfs /devices/virtual/net                                     u:object_r:sysfs_net:s0
 genfscon sysfs /devices/soc0                                            u:object_r:sysfs_soc:s0
 genfscon sysfs /bus/msm_subsys                                          u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /module/subsystem_restart                                u:object_r:sysfs_msm_subsys_restart:s0

--- a/vendor/keystore.te
+++ b/vendor/keystore.te
@@ -1,2 +1,0 @@
-# Legacy keystore for tone and loire
-allow keystore system_file:dir { open read };

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -27,9 +27,6 @@ set_prop(netmgrd, vendor_net_prop)
 set_prop(netmgrd, net_rmnet_prop)
 get_prop(netmgrd, hwservicemanager_prop)
 
-# communicate with netd
-unix_socket_connect(netmgrd, netd, netd)
-
 allow netmgrd netmgrd_socket:dir w_dir_perms;
 allow netmgrd netmgrd_socket:sock_file create_file_perms;
 allow netmgrd self:netlink_xfrm_socket { create_socket_perms_no_ioctl nlmsg_write };

--- a/vendor/thermalserviced.te
+++ b/vendor/thermalserviced.te
@@ -1,1 +1,0 @@
-allow thermalserviced system_file:dir { open read };

--- a/vendor/usbd.te
+++ b/vendor/usbd.te
@@ -1,1 +1,0 @@
-allow usbd system_file:dir { open read };


### PR DESCRIPTION
This removes a couple temporary fixes that were necessary on Pie but can now be removed because Google fixed this upstream.

Please check a87ff28. Only one line needed to be removed to build the policy (separated into b1d56af), but these "coredomain patchups" do not seem necessary anymore (no denials, Loire works fine without the `keystore` rule). If anyone experiences problems/denials, we can always re-add them.

Also, take note of ac5c258: This removes `BOARD_SEPOLICY_VERS` which has a proper default (one that is similar to `$(PLATFORM_SDK_VERSION).0` but without the chance to have letters in it on preview sources).
You will see a `Warning: BOARD_SEPOLICY_VERS is not specified. Default to 0.0.` regardless! As explained in the commit, this is from external manifests that do not get the environment variable passed to `assemble_vintf`. They shouldn't, because only the main manifest contains a `<sepolicy>` element.