### PR TITLE
[DONOTMERGE] [LA.UM.7.1.r1] Convert to QRTR sockets

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -17,3 +17,5 @@
   once all devices use "compatible" props
 - b/core-sp-hal: Remove sp-hal file labels once audioserver/cameraserver and
   their associated libs no longer access vendor files
+- b/deprecate-old-ipc-router: Remove 4.9 ipc-router compatibility `socket'
+  when kernel 4.14 is final. ioctl defines and macros can be removed as well.

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -125,7 +125,7 @@
 #
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.msm89(52|96|98)\.so  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sdm(660|845)\.so     u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor|odm)/lib(64)?/libqdMetaData\.so                u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/libqdMetaData(\.legacy)?\.so     u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqservice\.so                  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqdutils\.so                   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libadreno_utils\.so              u:object_r:same_process_hal_file:s0

--- a/vendor/hal_camera_default.te
+++ b/vendor/hal_camera_default.te
@@ -1,7 +1,8 @@
 vndbinder_use(hal_camera_default);
 allow hal_camera_default qdisplay_service:service_manager find;
 
-allow hal_camera_default self:socket { create ioctl read write };
+qrtr_socket_create(hal_camera_default)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm hal_camera self:socket ioctl { IPC_ROUTER_IOCTL_LOOKUP_SERVER IPC_ROUTER_IOCTL_BIND_CONTROL_PORT };
 
 allow hal_camera_default {

--- a/vendor/hal_gnss_qti.te
+++ b/vendor/hal_gnss_qti.te
@@ -28,7 +28,8 @@ allow hal_gnss_qti location_vendor_data_file:fifo_file { open read setattr write
 allow hal_gnss_qti location_vendor_data_file:dir create_dir_perms;
 allow hal_gnss_qti location_vendor_data_file:sock_file write;
 
-allow hal_gnss_qti self:socket create_socket_perms;
+qrtr_socket_create(hal_gnss_qti)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm hal_gnss_qti self:socket ioctl msm_sock_ipc_ioctls;
 
 unix_socket_connect(hal_gnss_qti, netmgrd, netmgrd)

--- a/vendor/hal_imsrtp.te
+++ b/vendor/hal_imsrtp.te
@@ -12,7 +12,8 @@ add_hwservice(hal_imsrtp, hal_imsrtp_hwservice)
 
 unix_socket_connect(hal_imsrtp, ims, ims)
 
-allow hal_imsrtp self:socket create_socket_perms;
+qrtr_socket_create(hal_imsrtp)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm hal_imsrtp self:socket ioctl msm_sock_ipc_ioctls;
 
 allow hal_imsrtp self:capability net_bind_service;

--- a/vendor/hal_sensors_default.te
+++ b/vendor/hal_sensors_default.te
@@ -1,5 +1,6 @@
 # interact with the sensors low power island (SLPI) CPU
-allow hal_sensors_default self:socket { create ioctl read write };
+qrtr_socket_create(hal_sensors_default)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm hal_sensors_default self:socket ioctl msm_sock_ipc_ioctls;
 
 userdebug_or_eng(`

--- a/vendor/ims.te
+++ b/vendor/ims.te
@@ -13,11 +13,12 @@ unix_socket_connect(ims, property, init)
 
 allow ims self:capability net_bind_service;
 
-allow ims self:socket create_socket_perms;
+qrtr_socket_create(ims)
 allow ims ims_socket:sock_file write;
 allow ims self:netlink_generic_socket create_socket_perms_no_ioctl;
 allow ims netmgrd_socket:dir search;
 allow ims netmgrd_socket:sock_file w_file_perms;
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm ims self:socket ioctl msm_sock_ipc_ioctls;
 allowxperm ims self:udp_socket ioctl RMNET_IOCTL_EXTENDED;
 

--- a/vendor/ioctl_defines
+++ b/vendor/ioctl_defines
@@ -1,6 +1,7 @@
 # socket ioctls
 define(`RMNET_IOCTL_EXTENDED', `0x000089FD')
 
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 # socket ioctls defined in the kernel in include/uapi/linux/msm_ipc.h
 define(`IPC_ROUTER_IOCTL_GET_VERSION', `0x0000c300')
 define(`IPC_ROUTER_IOCTL_GET_MTU', `0x0000c301')

--- a/vendor/ioctl_macros
+++ b/vendor/ioctl_macros
@@ -1,3 +1,4 @@
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 define(`msm_sock_ipc_ioctls', `{
 IPC_ROUTER_IOCTL_GET_VERSION
 IPC_ROUTER_IOCTL_GET_MTU

--- a/vendor/irsc_util.te
+++ b/vendor/irsc_util.te
@@ -3,5 +3,6 @@ type irsc_util_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(irsc_util)
 
-allow irsc_util self:socket create_socket_perms;
+qrtr_socket_create(irsc_util)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm irsc_util self:socket ioctl msm_sock_ipc_ioctls;

--- a/vendor/mlog_qmi.te
+++ b/vendor/mlog_qmi.te
@@ -4,7 +4,8 @@ type mlog_qmi_exec, exec_type, vendor_file_type, file_type;
 init_daemon_domain(mlog_qmi)
 
 allow mlog_qmi kernel:system module_request;
-allow mlog_qmi self:socket create_socket_perms;
+qrtr_socket_create(mlog_qmi)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm mlog_qmi self:socket ioctl msm_sock_ipc_ioctls;
 
 allow mlog_qmi self:capability net_raw;

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -33,8 +33,11 @@ allow netmgrd self:netlink_xfrm_socket { create_socket_perms_no_ioctl nlmsg_writ
 allow netmgrd self:netlink_generic_socket create_socket_perms_no_ioctl;
 allow netmgrd self:netlink_route_socket nlmsg_write;
 allow netmgrd self:netlink_socket create_socket_perms_no_ioctl;
-allow netmgrd self:socket create_socket_perms;
+
+qrtr_socket_create(netmgrd)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm netmgrd self:socket ioctl msm_sock_ipc_ioctls;
+
 allowxperm netmgrd self:udp_socket ioctl priv_sock_ioctls;
 
 allow netmgrd qmuxd_socket:dir w_dir_perms;

--- a/vendor/pd_services.te
+++ b/vendor/pd_services.te
@@ -10,7 +10,8 @@ allow pd_mapper self:capability { setgid setpcap setuid net_bind_service };
 
 allow pd_mapper { vendor_firmware_file vendor_file }:dir r_dir_perms;
 
-allow pd_mapper self:socket create_socket_perms;
+qrtr_socket_create(pd_mapper)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm pd_mapper self:socket ioctl IPC_ROUTER_IOCTL_BIND_CONTROL_PORT;
 
 r_dir_file(pd_mapper, sysfs_msm_subsys)

--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -17,7 +17,8 @@ set_prop(per_mgr, vendor_peripheral_prop)
 
 allow per_mgr self:capability net_bind_service;
 
-allow per_mgr self:socket create_socket_perms;
+qrtr_socket_create(per_mgr)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm per_mgr self:socket ioctl msm_sock_ipc_ioctls;
 allow per_mgr ssr_device:chr_file { open read };
 allow per_mgr device:dir search;

--- a/vendor/qmuxd.te
+++ b/vendor/qmuxd.te
@@ -8,7 +8,8 @@ allow qmuxd qmuxd_socket:sock_file create_file_perms;
 
 allow qmuxd smd_device:chr_file rw_file_perms;
 
-allow qmuxd self:socket create_socket_perms;
+qrtr_socket_create(qmuxd)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm qmuxd self:socket ioctl msm_sock_ipc_ioctls;
 
 wakelock_use(qmuxd)

--- a/vendor/qrtr.te
+++ b/vendor/qrtr.te
@@ -3,3 +3,5 @@ type qrtr_exec, exec_type, vendor_file_type, file_type;
 
 net_domain(qrtr)
 init_daemon_domain(qrtr)
+
+allow qrtr self:qipcrtr_socket create_socket_perms_no_ioctl;

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -26,6 +26,7 @@ unix_socket_connect(rild, netmgrd, netmgrd)
 add_hwservice(rild, vnd_ims_radio_hwservice)
 add_hwservice(rild, vnd_qcrilhook_hwservice)
 
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allow rild self:socket ioctl;
 allowxperm rild self:socket ioctl msm_sock_ipc_ioctls;
 

--- a/vendor/rmt_storage.te
+++ b/vendor/rmt_storage.te
@@ -28,7 +28,8 @@ allow rmt_storage sysfs_rmtfs:file r_file_perms;
 allow rmt_storage debugfs_rmt_storage:dir search;
 allow rmt_storage debugfs_rmt_storage:file w_file_perms;
 
-allow rmt_storage self:socket create_socket_perms;
+qrtr_socket_create(rmt_storage)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm rmt_storage self:socket ioctl IPC_ROUTER_IOCTL_BIND_CONTROL_PORT;
 
 allow rmt_storage kmsg_device:chr_file w_file_perms;

--- a/vendor/sct.te
+++ b/vendor/sct.te
@@ -3,7 +3,8 @@ type sct_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(sct)
 
-allow sct self:socket create_socket_perms;
+qrtr_socket_create(sct)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm sct self:socket ioctl msm_sock_ipc_ioctls;
 
 allow sct self:capability net_raw;

--- a/vendor/sensors.te
+++ b/vendor/sensors.te
@@ -12,7 +12,8 @@ userdebug_or_eng(`
   allow sensors diag_device:chr_file rw_file_perms;
 ')
 
-allow sensors self:socket create_socket_perms;
+qrtr_socket_create(sensors)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm sensors self:socket ioctl msm_sock_ipc_ioctls;
 
 allow sensors persist_sensors_file:dir rw_dir_perms;

--- a/vendor/system_server.te
+++ b/vendor/system_server.te
@@ -1,9 +1,6 @@
 binder_call(system_server, hal_camera_default)
 binder_call(system_server, hal_tetheroffload_default)
 
-allow system_server self:socket ioctl;
-allowxperm system_server self:socket ioctl msm_sock_ipc_ioctls;
-
 allow system_server wlan_device:chr_file rw_file_perms;
 
 # Input files in /vendor/usr/
@@ -16,7 +13,8 @@ allow system_server audioserver:file w_file_perms;
 allow system_server hal_audio_default:file w_file_perms;
 
 allow system_server netmgrd_socket:dir r_dir_perms;
-allow system_server self:socket ioctl;
+qrtr_socket_create(system_server)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm system_server self:socket ioctl msm_sock_ipc_ioctls;
 
 # radio

--- a/vendor/ta_qmi.te
+++ b/vendor/ta_qmi.te
@@ -5,7 +5,8 @@ init_daemon_domain(ta_qmi)
 
 allow ta_qmi kernel:system module_request;
 
-allow ta_qmi self:socket create_socket_perms;
+qrtr_socket_create(ta_qmi)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm ta_qmi self:socket ioctl msm_sock_ipc_ioctls;
 
 unix_socket_connect(ta_qmi, tad, tad)

--- a/vendor/te_macros
+++ b/vendor/te_macros
@@ -15,3 +15,13 @@ define(`r_dir_rw_file', `
 allow $1 $2:dir r_dir_perms;
 allow $1 $2:{ file lnk_file } rw_file_perms;
 ')
+
+#####################################
+# qrtr_socket_create(domain)
+# Allow the specified domain to create and access
+# a qipcrtr_socket.
+define(`qrtr_socket_create', `
+allow $1 self:qipcrtr_socket create_socket_perms_no_ioctl;
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
+allow $1 self:socket create_socket_perms;
+')

--- a/vendor/wcnss_service.te
+++ b/vendor/wcnss_service.te
@@ -16,7 +16,8 @@ allow wcnss_service self:capability {
     net_bind_service
 };
 
-allow wcnss_service self:socket create_socket_perms;
+qrtr_socket_create(wcnss_service)
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm wcnss_service self:socket ioctl msm_sock_ipc_ioctls;
 allowxperm wcnss_service self:udp_socket ioctl { SIOCIWFIRSTPRIV_05 SIOCSIFFLAGS };
 allow wcnss_service self:netlink_generic_socket create_socket_perms_no_ioctl;


### PR DESCRIPTION
Add a macro that allows interaction with qipcrtr_socket files. This
macro provides legacy access to ipc-router sockets. When 4.14 is final
and sepolicy branches off for "legacy" 4.9 compatibility, the socket
allow and related allowxperm rules must be removed.

### TODO
I am not too sure about the macro, since we already had to label every `allowxperm` with a `TODO`. Might as well leave the `allow xyz self:socket ...;` in place and remove the (now useless) macro.

Pinging @ix5, my partner-in-crime when it comes to sepolicy for an opinion.