### PR TITLE
sepolicy: add LDO vibrator sys path

### DIFF
--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -56,6 +56,8 @@ genfscon sysfs /devices/platform/soc/soc:qcom,kgsl-hyp                  u:object
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws@1e08000           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/0.qcom,rmtfs_sharedmem             u:object_r:sysfs_rmtfs:s0
 
+genfscon sysfs /devices/platform/soc/soc:ldo_vibrator                   u:object_r:sysfs_vibrator:s0
+
 genfscon sysfs /module/diagchar                                         u:object_r:sysfs_diag:s0
 genfscon sysfs /kernel/irq_helper/irq_blacklist_on                      u:object_r:sysfs_irq:s0
 genfscon sysfs /kernel/boot_wlan/boot_wlan                              u:object_r:sysfs_boot_wlan:s0


### PR DESCRIPTION
01-17 08:56:54.459     1     1 W init    : type=1400 audit(0.0:5): avc: denied { setattr } for name=trigger dev=sysfs ino=44654 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0
01-17 08:56:54.460     1     1 W init    : type=1400 audit(0.0:6): avc: denied { setattr } for name=activate dev=sysfs ino=44663 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0
01-17 08:56:54.460     1     1 W init    : type=1400 audit(0.0:7): avc: denied { setattr } for name=brightness dev=sysfs ino=44652 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0
01-17 08:56:54.460     1     1 W init    : type=1400 audit(0.0:8): avc: denied { setattr } for name=duration dev=sysfs ino=44662 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0
01-17 08:56:54.460     1     1 W init    : type=1400 audit(0.0:9): avc: denied { setattr } for name=state dev=sysfs ino=44661 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>