### PR TITLE
FIXUP: rild: Allow qipcrtr socket access.

### DIFF
--- a/vendor/hal_bluetooth_default.te
+++ b/vendor/hal_bluetooth_default.te
@@ -10,6 +10,10 @@ allow hal_bluetooth_default bluetooth_vendor_data_file:dir create_dir_perms;
 allow hal_bluetooth_default bluetooth_vendor_data_file:file create_file_perms;
 
 allow hal_bluetooth_default kernel:system module_request;
+qrtr_socket_create(hal_bluetooth_default)
+# TODO (b/deprecate-old-ipc-router):
+# Test if this socket is for the (now deprecated) 4.9 ipc-router, since there
+# is no allowxperm for msm_sock_ipc_ioctls.
 allow hal_bluetooth_default self:socket create;
 
 set_prop(hal_bluetooth_default, wc_prop)

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -26,6 +26,7 @@ unix_socket_connect(rild, netmgrd, netmgrd)
 add_hwservice(rild, vnd_ims_radio_hwservice)
 add_hwservice(rild, vnd_qcrilhook_hwservice)
 
+qrtr_socket_create(rild)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allow rild self:socket ioctl;
 allowxperm rild self:socket ioctl msm_sock_ipc_ioctls;


### PR DESCRIPTION
This rule magically disappeared from the previous commit (https://github.com/sonyxperiadev/device-sony-sepolicy/pull/538)

**Please** Do a quick compile test! I vaguely remember something generating a `neverallow`, perhaps that was this rule...