### PR TITLE
[Q-Compat] Label and access vibrator paths

### DIFF
--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -53,6 +53,8 @@ genfscon sysfs /devices/platform/soc/soc:qcom,gpubw                     u:object
 genfscon sysfs /devices/platform/soc/soc:qcom,kgsl-hyp                  u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/soc:qcom,ipa_fws@1e08000           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/0.qcom,rmtfs_sharedmem             u:object_r:sysfs_rmtfs:s0
+genfscon sysfs /class/leds/vibrator                                     u:object_r:sysfs_vibrator:s0
+genfscon sysfs /devices/platform/soc/soc:ldo_vibrator/leds/vibrator     u:object_r:sysfs_vibrator:s0
 
 genfscon sysfs /module/diagchar                                         u:object_r:sysfs_diag:s0
 genfscon sysfs /kernel/irq_helper/irq_blacklist_on                      u:object_r:sysfs_irq:s0

--- a/vendor/hal_vibrator_default.te
+++ b/vendor/hal_vibrator_default.te
@@ -1,4 +1,3 @@
-allow hal_vibrator_default sysfs_leds:dir search;
-allow hal_vibrator_default sysfs_msm_subsys:dir search;
-allow hal_vibrator_default sysfs_msm_subsys:file { open read write };
-allow hal_vibrator_default sysfs_leds:file rw_file_perms;
+r_dir_rw_file(hal_vibrator_default, sysfs_leds)
+r_dir_rw_file(hal_vibrator_default, sysfs_vibrator)
+r_dir_rw_file(hal_vibrator_default, sysfs_msm_subsys)


### PR DESCRIPTION
Denials:
```
avc: denied { open } for path="/sys/devices/platform/soc/soc:ldo_vibrator/leds/vibrator/trigger" \
  dev="sysfs" ino=39952 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=file
avc: denied { read write } for comm="android.hardwar" name="activate" dev="sysfs" \
  ino=39961 scontext=u:r:hal_vibrator_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file
```

Ah, my sweet enforcing state shall be restored swiftly on 10... 
(The vibrator HAL fails without this and craps out, stalling boot.)