### PR TITLE
[VERIFYME] file_contexts: Label /dev/adsprpc-smd-secure

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -18,6 +18,7 @@
 /dev/qseecom                                    u:object_r:tee_device:s0
 /dev/jpeg[0-9]*                                 u:object_r:video_device:s0
 /dev/adsprpc-smd                                u:object_r:qdsp_device:s0
+/dev/adsprpc-smd-secure                         u:object_r:qdsp_device:s0
 /dev/mdss_rotator                               u:object_r:graphics_device:s0
 /dev/msm_.*                                     u:object_r:audio_device:s0
 /dev/avtimer                                    u:object_r:avtimer_device:s0


### PR DESCRIPTION
See https://github.com/sonyxperiadev/device-sony-tama/pull/66

> The new adsprpc driver opens one device for secure transactions and
> one for unsecured transactions.