### PR TITLE
sepolicy: avoid wifi denials

### DIFF
--- a/vendor/hal_wifi_default.te
+++ b/vendor/hal_wifi_default.te
@@ -5,3 +5,4 @@ r_dir_file(hal_wifi_default, debugfs_wlan)
 
 allow hal_wifi_default kernel:system module_request;
 allow hal_wifi_default tombstone_wifi_data_file:dir rw_dir_perms;
+allow hal_wifi_default tombstone_wifi_data_file:file create_file_perms;


### PR DESCRIPTION
11-22 12:44:53.700   691   691 W wifi@1.0-servic: type=1400 audit(0.0:81): avc: denied { create } for name=driver_prints_rbXURHagokgH scontext=u:r:hal_wifi_default:s0 tcontext=u:object_r:tombstone_wifi_data_file:s0 tclass=file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>