### PR TITLE
[LA.UM.7.1.r1] Sepolicy for kernel 4.14 paths and new HALs

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -72,6 +72,7 @@ type audio_vendor_data_file, file_type, data_file_type;
 type bluetooth_vendor_data_file, file_type, data_file_type;
 type camera_vendor_data_file, file_type, data_file_type;
 type cashsvr_vendor_data_file, file_type, data_file_type;
+type display_vendor_data_file, file_type, data_file_type;
 type ipa_vendor_data_file, file_type, data_file_type;
 type location_vendor_data_file, file_type, data_file_type;
 type netmgr_vendor_data_file, file_type, data_file_type;

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -25,6 +25,7 @@ type sysfs_system_sleep_stats, sysfs_type, fs_type;
 type sysfs_timestamp_switch, sysfs_type, fs_type;
 type sysfs_tof_sensor, fs_type, sysfs_type;
 type sysfs_usb_supply, sysfs_type, fs_type;
+type sysfs_wlan_power_stats, fs_type, sysfs_type;
 
 type debugfs_clk, debugfs_type, fs_type;
 type debugfs_icnss, debugfs_type, fs_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -96,6 +96,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health@2\.0-service\.sony                  u:object_r:hal_health_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.usb@1\.0-service\.basic                    u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0
+/(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.allocator-service             u:object_r:hal_graphics_allocator_default_exec:s0
 
 # sysfs paths
 # Input device control nodes, mainly for CASH to control power
@@ -183,6 +184,11 @@
 /(system/vendor|vendor)/lib(64)?/camera\.device@3\.3-impl\.so                           u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor)/lib(64)?/camera\.device@3\.4-impl\.so                           u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor)/lib(64)?/camera\.device@3\.4-external-impl\.so                  u:object_r:same_process_hal_file:s0
+
+# Graphics mapper
+/(system/vendor|vendor)/lib(64)?/hw/android\.hardware\.graphics\.mapper@3\.0-impl-qti-display\.so       u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapper@[0-9]+\.[0-9]+\.so              u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapperextensions@1\.[0-9]+\.so         u:object_r:same_process_hal_file:s0
 
 # data files
 /data/vendor/audio(/.*)?               u:object_r:audio_vendor_data_file:s0

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -193,8 +193,9 @@
 # data files
 /data/vendor/audio(/.*)?               u:object_r:audio_vendor_data_file:s0
 /data/vendor/bluetooth(/.*)?           u:object_r:bluetooth_vendor_data_file:s0
-/data/vendor/cashsvr(/.*)?             u:object_r:cashsvr_vendor_data_file:s0
 /data/vendor/camera(/.*)?              u:object_r:camera_vendor_data_file:s0
+/data/vendor/cashsvr(/.*)?             u:object_r:cashsvr_vendor_data_file:s0
+/data/vendor/display(/.*)?             u:object_r:display_vendor_data_file:s0
 /data/vendor/ipa(/.*)?                 u:object_r:ipa_vendor_data_file:s0
 /data/vendor/location(/.*)?            u:object_r:location_vendor_data_file:s0
 /data/vendor/netmgr(/.*)?              u:object_r:netmgr_vendor_data_file:s0

--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -62,6 +62,7 @@ genfscon sysfs /bus/mmc/devices/mmc0:0001                               u:object
 genfscon sysfs /module/diagchar                                         u:object_r:sysfs_diag:s0
 genfscon sysfs /kernel/irq_helper/irq_blacklist_on                      u:object_r:sysfs_irq:s0
 genfscon sysfs /kernel/boot_wlan/boot_wlan                              u:object_r:sysfs_boot_wlan:s0
+genfscon sysfs /kernel/wlan/power_stats                                 u:object_r:sysfs_wlan_power_stats:s0
 
 genfscon sysfs /power/rpmh_stats/master_stats                           u:object_r:sysfs_rpm:s0
 genfscon sysfs /power/system_sleep/stats                                u:object_r:sysfs_system_sleep_stats:s0

--- a/vendor/hal_camera_default.te
+++ b/vendor/hal_camera_default.te
@@ -22,6 +22,7 @@ allow hal_camera_default sysfs_camera:dir r_dir_perms;
 allow hal_camera_default sysfs_camera:file r_file_perms;
 
 allow hal_camera_default gpu_device:chr_file rw_file_perms;
+allow hal_camera_default qdsp_device:chr_file r_file_perms;
 
 allow hal_camera_default hal_power_default:unix_stream_socket connectto;
 allow hal_camera_default powerhal_socket:dir search;

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -28,6 +28,8 @@ r_dir_rw_file(hal_graphics_composer_default, sysfs_graphics)
 # Access /mnt/vendor/persist/display
 allow hal_graphics_composer_default mnt_vendor_file:dir search;
 r_dir_file(hal_graphics_composer_default, persist_display_file)
+# Access /data/vendor/display/
+rw_dir_file(hal_graphics_composer_default, display_vendor_data_file)
 
 # HWC_UeventThread
 allow hal_graphics_composer_default self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -11,3 +11,4 @@ r_dir_file(hal_power_default, debugfs_wlan)
 allow hal_power_default debugfs_rpm:file r_file_perms;
 allow hal_power_default sysfs_system_sleep_stats:file r_file_perms;
 allow hal_power_default sysfs_rpm:file r_file_perms;
+allow hal_power_default sysfs_wlan_power_stats:file r_file_perms;

--- a/vendor/hwservice.te
+++ b/vendor/hwservice.te
@@ -1,6 +1,7 @@
-type hal_display_config_hwservice, hwservice_manager_type;
-type nxpnfc_hwservice,             hwservice_manager_type;
-type nxpese_hwservice,             hwservice_manager_type;
-type vnd_qcrilhook_hwservice,      hwservice_manager_type;
-type hal_imsrtp_hwservice,         hwservice_manager_type;
-type vnd_ims_radio_hwservice,      hwservice_manager_type;
+type hal_display_config_hwservice,      hwservice_manager_type;
+type nxpnfc_hwservice,                  hwservice_manager_type;
+type nxpese_hwservice,                  hwservice_manager_type;
+type vnd_qcrilhook_hwservice,           hwservice_manager_type;
+type hal_imsrtp_hwservice,              hwservice_manager_type;
+type vnd_ims_radio_hwservice,           hwservice_manager_type;
+type vnd_data_connection_hwservice,     hwservice_manager_type;

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -11,3 +11,6 @@ vendor.qti.hardware.radio.uim::IUim                                     u:object
 vendor.qti.hardware.radio.lpa::IUimLpa                                  u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.radio.qtiradio::IQtiRadio                           u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.data.connection::IDataConnection                    u:object_r:vnd_data_connection_hwservice:s0
+# QTI HAL interfaces for display services:
+vendor.qti.hardware.display.mapper::IQtiMapper                          u:object_r:hal_graphics_mapper_hwservice:s0
+vendor.qti.hardware.display.allocator::IQtiAllocator                    u:object_r:hal_graphics_allocator_hwservice:s0

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -10,3 +10,4 @@ vendor.qti.hardware.radio.uim_remote_server::IUimRemoteServiceServer    u:object
 vendor.qti.hardware.radio.uim::IUim                                     u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.radio.lpa::IUimLpa                                  u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.radio.qtiradio::IQtiRadio                           u:object_r:hal_telephony_hwservice:s0
+vendor.qti.hardware.data.connection::IDataConnection                    u:object_r:vnd_data_connection_hwservice:s0

--- a/vendor/kernel.te
+++ b/vendor/kernel.te
@@ -5,6 +5,9 @@ userdebug_or_eng(`
   # otherwise debug files are not created there.
   r_dir_file(kernel, debugfs_wlan)
 ')
+
+allow kernel self:qipcrtr_socket create_socket_perms_no_ioctl;
+
 # Ignore in user builds
 dontaudit kernel self:socket create;
 

--- a/vendor/qcrilam_app.te
+++ b/vendor/qcrilam_app.te
@@ -17,3 +17,5 @@ allow qcrilam_app vnd_qcrilhook_hwservice:hwservice_manager find;
 
 # Interact with rild
 binder_call(qcrilam_app, rild)
+
+allow qcrilam_app cgroup:file w_file_perms;

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -26,6 +26,7 @@ unix_socket_connect(rild, netmgrd, netmgrd)
 
 add_hwservice(rild, vnd_ims_radio_hwservice)
 add_hwservice(rild, vnd_qcrilhook_hwservice)
+add_hwservice(rild, vnd_data_connection_hwservice)
 
 qrtr_socket_create(rild)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -9,6 +9,7 @@ not_compatible_property(`
   set_prop(rild, radio_prop)
 ')
 set_prop(rild, vendor_radio_prop)
+get_prop(rild, vendor_net_prop)
 
 allow rild radio_vendor_data_file:dir create_dir_perms;
 allow rild radio_vendor_data_file:file create_file_perms;

--- a/vendor/rmt_storage.te
+++ b/vendor/rmt_storage.te
@@ -19,6 +19,8 @@ allow rmt_storage modem_block_device:blk_file rw_file_perms;
 allow rmt_storage uio_device:chr_file rw_file_perms;
 allow rmt_storage block_device:dir { open read search };
 
+r_dir_file(rmt_storage, sysfs_msm_subsys)
+
 allow rmt_storage sysfs_uio:dir r_dir_perms;
 allow rmt_storage sysfs_uio:lnk_file r_file_perms;
 

--- a/vendor/sensors.te
+++ b/vendor/sensors.te
@@ -18,6 +18,7 @@ allowxperm sensors self:socket ioctl msm_sock_ipc_ioctls;
 
 allow sensors persist_sensors_file:dir rw_dir_perms;
 allow sensors persist_sensors_file:file create_file_perms;
+allow sensors persist_sensors_file:fifo_file r_file_perms;
 allow sensors persist_file:dir { getattr search };
 
 # Search /data

--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -6,6 +6,8 @@ init_daemon_domain(sscrpcd)
 
 allow sscrpcd self:capability net_bind_service;
 
+allow sscrpcd self:qipcrtr_socket create_socket_perms_no_ioctl;
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allow sscrpcd self:socket create;
 
 allow sscrpcd qdsp_device:chr_file { open read ioctl };

--- a/vendor/tad.te
+++ b/vendor/tad.te
@@ -25,6 +25,8 @@ type_transition tad vendor_data_file:{ dir file } rfs_file;
 type_transition tad persist_rfs_file:{ dir file } persist_rfs_file;
 
 #For QMI sockets and IPCR Sockets
+allow tad self:qipcrtr_socket create_socket_perms_no_ioctl;
+# TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allow tad self:socket create_socket_perms_no_ioctl;
 
 #For Wakelocks


### PR DESCRIPTION
This is the first iteration of rules for the new HALs that come with kernel 4.14. So far no denials have been spotted during short normal use (apart rogue apps trying to read anything and everything in the system...).

@ix5 I need your opinion on the following. ~Please do not merge this until we have resolved these points.~ Discussed, ready to merge!
- Libs with multiple versions: Is `mapper@[0-9]+\.[0-9]+\.so` ok or do you prefer all the versions explicitly listed? (1.0, 1.1 and 3.0 in this case)
- The new CAF/QTI interfaces (for the graphics mapper and allocator) inherit from AOSP (`interface IQti* extends I*`) and are supposed to bolt right into the existing structure. I don't think it makes any sense to redefine entire domains and pretty much duplicate AOSP policy when we can give these interface implementations the same label as a direct implemention of the AOSP HIDL would have gotten?