### PR TITLE
[2/2] QcRilAm: Grant access to isub (radio_service) for sim information.

### DIFF
--- a/vendor/qcrilam_app.te
+++ b/vendor/qcrilam_app.te
@@ -11,6 +11,8 @@ dontaudit qcrilam_app app_data_file:dir { getattr search };
 allow qcrilam_app activity_service:service_manager find;
 # Find media.audio_flinger
 allow qcrilam_app audioserver_service:service_manager find;
+# Find isub
+allow qcrilam_app radio_service:service_manager find;
 
 # Find the vendor.qti.hardware.radio.am::IQcRilAudio HIDL service
 allow qcrilam_app vnd_qcrilhook_hwservice:hwservice_manager find;


### PR DESCRIPTION
For https://github.com/sonyxperiadev/QcRilAm/pull/4

QcRilAm has been converted to use only SDK APIs instead of private ones,
for building on devices with API level 28 and up.
The app now has to get the sim count through SubscriptionManager, which
internally uses the ISub interface.

This fixes the following denial:
denied  { find } for service=isub scontext=u:r:qcrilam_app:s0
tcontext=u:object_r:radio_service:s0 tclass=service_manager