### PR TITLE
[LA.UM.7.1.r1] Second sepolicy dump for 4.14

### DIFF
--- a/vendor/hal_bootctl_default.te
+++ b/vendor/hal_bootctl_default.te
@@ -16,6 +16,8 @@ allow hal_bootctl_default modem_block_device:blk_file getattr;
 allow hal_bootctl_default system_block_device:blk_file getattr;
 allow hal_bootctl_default ramdump_block_device:blk_file getattr;
 allow hal_bootctl_default adsprpcd_block_device:blk_file getattr;
+allow hal_bootctl_default dtbo_block_device:blk_file getattr;
+allow hal_bootctl_default vbmeta_block_device:blk_file getattr;
 
 # Write to the XBL devices.
 allow hal_bootctl_default xbl_block_device:blk_file rw_file_perms;

--- a/vendor/hal_gnss_qti.te
+++ b/vendor/hal_gnss_qti.te
@@ -23,6 +23,8 @@ dontaudit hal_gnss_qti diag_device:chr_file { read write };
 
 binder_call(hal_gnss_qti, per_mgr)
 
+get_prop(hal_gnss_qti, vendor_net_prop)
+
 # /data/vendor/location
 allow hal_gnss_qti location_vendor_data_file:fifo_file { open read setattr write };
 allow hal_gnss_qti location_vendor_data_file:dir create_dir_perms;

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -29,7 +29,7 @@ r_dir_rw_file(hal_graphics_composer_default, sysfs_graphics)
 allow hal_graphics_composer_default mnt_vendor_file:dir search;
 r_dir_file(hal_graphics_composer_default, persist_display_file)
 # Access /data/vendor/display/
-rw_dir_file(hal_graphics_composer_default, display_vendor_data_file)
+create_dir_file(hal_graphics_composer_default, display_vendor_data_file)
 
 # HWC_UeventThread
 allow hal_graphics_composer_default self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;

--- a/vendor/hal_wifi_default.te
+++ b/vendor/hal_wifi_default.te
@@ -5,3 +5,5 @@ r_dir_file(hal_wifi_default, debugfs_wlan)
 
 allow hal_wifi_default kernel:system module_request;
 allow hal_wifi_default tombstone_wifi_data_file:dir rw_dir_perms;
+
+set_prop(hal_wifi_default, vendor_wifi_prop)

--- a/vendor/irsc_util.te
+++ b/vendor/irsc_util.te
@@ -6,3 +6,5 @@ init_daemon_domain(irsc_util)
 qrtr_socket_create(irsc_util)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm irsc_util self:socket ioctl msm_sock_ipc_ioctls;
+
+allow irsc_util kernel:system module_request;

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -32,4 +32,5 @@ vendor.sys.keymaster.loaded     u:object_r:vendor_keymaster_prop:s0
 vendor.sys.listeners.           u:object_r:vendor_tee_listener_prop:s0
 vendor.usb.                     u:object_r:vendor_usb_prop:s0
 vendor.usb.config               u:object_r:vendor_usb_config_prop:s0
+vendor.wlan.                    u:object_r:vendor_wifi_prop:s0
 wc_transport.                   u:object_r:wc_prop:s0

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -9,7 +9,7 @@ not_compatible_property(`
   set_prop(rild, radio_prop)
 ')
 set_prop(rild, vendor_radio_prop)
-get_prop(rild, vendor_net_prop)
+set_prop(rild, vendor_net_prop)
 
 allow rild radio_vendor_data_file:dir create_dir_perms;
 allow rild radio_vendor_data_file:file create_file_perms;

--- a/vendor/te_macros
+++ b/vendor/te_macros
@@ -8,6 +8,15 @@ allow $1 $2:{ file lnk_file } rw_file_perms;
 ')
 
 #####################################
+# create_dir_file(domain, type)
+# Allow the specified domain to read, write and create directories,
+# files and symbolic links of the specified type.
+define(`create_dir_file', `
+allow $1 $2:dir create_dir_perms;
+allow $1 $2:{ file lnk_file } create_file_perms;
+')
+
+#####################################
 # r_dir_rw_file(domain, type)
 # Allow the specified domain to read and write files,
 # without modifying the directories or their contents.


### PR DESCRIPTION
Follows on the changes made in https://github.com/sonyxperiadev/device-sony-sepolicy/pull/550

See the commits and their respective descriptions/changes for more details.