### PR TITLE
[WIP] dpmQmiMgr and Kumano v4 policy

### DIFF
--- a/vendor/dpmqmimgr.te
+++ b/vendor/dpmqmimgr.te
@@ -11,3 +11,4 @@ add_hwservice(dpmqmimgr, vnd_qti_dpm_hwservice)
 allow dpmqmimgr self:qipcrtr_socket create_socket_perms_no_ioctl;
 
 r_dir_file(dpmqmimgr, sysfs_msm_subsys)
+r_dir_file(dpmqmimgr, sysfs_esoc)

--- a/vendor/dpmqmimgr.te
+++ b/vendor/dpmqmimgr.te
@@ -3,3 +3,11 @@ type dpmqmimgr_exec, exec_type, vendor_file_type, file_type;
 
 net_domain(dpmqmimgr)
 init_daemon_domain(dpmqmimgr)
+
+hwbinder_use(dpmqmimgr)
+get_prop(dpmqmimgr, hwservicemanager_prop)
+add_hwservice(dpmqmimgr, vnd_qti_dpm_hwservice)
+
+allow dpmqmimgr self:qipcrtr_socket create_socket_perms_no_ioctl;
+
+r_dir_file(dpmqmimgr, sysfs_msm_subsys)

--- a/vendor/hal_bluetooth_default.te
+++ b/vendor/hal_bluetooth_default.te
@@ -1,10 +1,7 @@
 allow hal_bluetooth_default bt_device:chr_file rw_file_perms;
 allow hal_bluetooth_default serial_device:chr_file rw_file_perms;
-userdebug_or_eng(`
-  allow hal_bluetooth_default diag_device:chr_file rw_file_perms;
-')
-# Ignore in user builds
-dontaudit hal_bluetooth_default diag_device:chr_file rw_file_perms;
+
+rw_diag_device(hal_bluetooth_default)
 
 allow hal_bluetooth_default bluetooth_vendor_data_file:dir create_dir_perms;
 allow hal_bluetooth_default bluetooth_vendor_data_file:file create_file_perms;

--- a/vendor/hal_gnss_qti.te
+++ b/vendor/hal_gnss_qti.te
@@ -15,11 +15,7 @@ allow hal_gnss_qti qmuxd_socket:dir w_dir_perms;
 allow hal_gnss_qti qmuxd_socket:sock_file create_file_perms;
 unix_socket_connect(hal_gnss_qti, qmuxd, qmuxd)
 
-userdebug_or_eng(`
-  allow hal_gnss_qti diag_device:chr_file { read write };
-')
-# Ignore in user builds
-dontaudit hal_gnss_qti diag_device:chr_file { read write };
+rw_diag_device(hal_gnss_qti)
 
 binder_call(hal_gnss_qti, per_mgr)
 

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -9,11 +9,7 @@ add_service(hal_graphics_composer_default, qdisplay_service)
 add_hwservice(hal_graphics_composer_default, hal_display_config_hwservice)
 
 allow hal_graphics_composer_default { graphics_device video_device }:chr_file rw_file_perms;
-userdebug_or_eng(`
-  allow hal_graphics_composer_default diag_device:chr_file { ioctl open read write };
-')
-# Ignore in user builds
-dontaudit hal_graphics_composer_default diag_device:chr_file { ioctl open read write };
+rw_diag_device(hal_graphics_composer_default)
 
 allow hal_graphics_composer_default oemfs:dir search;
 allow hal_graphics_composer_default persist_display_file:dir getattr;

--- a/vendor/hal_imsrtp.te
+++ b/vendor/hal_imsrtp.te
@@ -21,11 +21,8 @@ allow hal_imsrtp self:capability net_bind_service;
 r_dir_file(hal_imsrtp, sysfs_msm_subsys)
 r_dir_file(hal_imsrtp, sysfs_soc)
 
-userdebug_or_eng(`
-  allow hal_imsrtp diag_device:chr_file { read write };
-')
+rw_diag_device(hal_imsrtp)
 
 get_prop(hal_imsrtp, qcom_ims_prop)
 
 dontaudit hal_imsrtp kernel:system module_request;
-dontaudit hal_imsrtp diag_device:chr_file { read write };

--- a/vendor/hal_imsrtp.te
+++ b/vendor/hal_imsrtp.te
@@ -20,6 +20,7 @@ allow hal_imsrtp self:capability net_bind_service;
 
 r_dir_file(hal_imsrtp, sysfs_msm_subsys)
 r_dir_file(hal_imsrtp, sysfs_soc)
+r_dir_file(hal_imsrtp, sysfs_esoc)
 
 rw_diag_device(hal_imsrtp)
 

--- a/vendor/hal_sensors_default.te
+++ b/vendor/hal_sensors_default.te
@@ -3,11 +3,7 @@ qrtr_socket_create(hal_sensors_default)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm hal_sensors_default self:socket ioctl msm_sock_ipc_ioctls;
 
-userdebug_or_eng(`
-  allow hal_sensors_default diag_device:chr_file rw_file_perms;
-')
-# Ignore in user builds
-dontaudit hal_sensors_default diag_device:chr_file { read write };
+rw_diag_device(hal_sensors_default)
 
 r_dir_file(hal_sensors_default, sysfs_msm_subsys);
 allow hal_sensors_default sysfs_esoc:dir r_dir_perms;

--- a/vendor/hwservice.te
+++ b/vendor/hwservice.te
@@ -5,6 +5,7 @@ type nxpnfc_hwservice,                  hwservice_manager_type;
 type vnd_data_connection_hwservice,     hwservice_manager_type;
 type vnd_ims_radio_hwservice,           hwservice_manager_type;
 type vnd_qcrilhook_hwservice,           hwservice_manager_type;
+type vnd_qti_dpm_hwservice,             hwservice_manager_type;
 type vnd_qti_ims_callinfo_hwservice,    hwservice_manager_type;
 type vnd_qti_imscms_hwservice,          hwservice_manager_type;
 type vnd_qti_uce_hwservice,             hwservice_manager_type;

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -18,3 +18,5 @@ vendor.qti.hardware.data.connection::IDataConnection                    u:object
 # QTI HAL interfaces for display services:
 vendor.qti.hardware.display.mapper::IQtiMapper                          u:object_r:hal_graphics_mapper_hwservice:s0
 vendor.qti.hardware.display.allocator::IQtiAllocator                    u:object_r:hal_graphics_allocator_hwservice:s0
+# QTI DPM:
+com.qualcomm.qti.dpm.api::IdpmQmi                                       u:object_r:vnd_qti_dpm_hwservice:s0

--- a/vendor/ims.te
+++ b/vendor/ims.te
@@ -31,6 +31,7 @@ allow ims qmuxd_socket:sock_file create_file_perms;
 
 r_dir_file(ims, sysfs_msm_subsys)
 r_dir_file(ims, sysfs_soc)
+r_dir_file(ims, sysfs_esoc)
 
 rw_diag_device(ims)
 

--- a/vendor/ims.te
+++ b/vendor/ims.te
@@ -32,11 +32,8 @@ allow ims qmuxd_socket:sock_file create_file_perms;
 r_dir_file(ims, sysfs_msm_subsys)
 r_dir_file(ims, sysfs_soc)
 
-userdebug_or_eng(`
-  allow ims diag_device:chr_file { read write };
-')
+rw_diag_device(ims)
 
 hwbinder_use(ims)
 
 dontaudit ims kernel:system module_request;
-dontaudit ims diag_device:chr_file { read write };

--- a/vendor/netmgrd.te
+++ b/vendor/netmgrd.te
@@ -44,11 +44,7 @@ allow netmgrd qmuxd_socket:dir w_dir_perms;
 allow netmgrd qmuxd_socket:sock_file create_file_perms;
 unix_socket_connect(netmgrd, qmuxd, qmuxd)
 
-userdebug_or_eng(`
-  allow netmgrd diag_device:chr_file { ioctl open read write };
-')
-# Ignore in user builds
-dontaudit netmgrd diag_device:chr_file { ioctl open read write };
+rw_diag_device(netmgrd)
 
 allow netmgrd sysfs_net:dir r_dir_perms;
 allow netmgrd sysfs_net:file rw_file_perms;

--- a/vendor/netutils_wrapper.te
+++ b/vendor/netutils_wrapper.te
@@ -3,11 +3,7 @@ allow netutils_wrapper netmgrd:fd use;
 allow netutils_wrapper netmgrd:fifo_file { getattr read write append };
 allow netutils_wrapper netmgrd:file r_file_perms;
 
-userdebug_or_eng(`
-  allow netutils_wrapper diag_device:chr_file { read write };
-')
-# Ignore in user builds
-dontaudit netutils_wrapper diag_device:chr_file { read write };
+rw_diag_device(netutils_wrapper)
 
 allow netutils_wrapper sysfs_soc:file read;
 

--- a/vendor/sensors.te
+++ b/vendor/sensors.te
@@ -8,9 +8,7 @@ allow sensors self:capability {
     net_bind_service
 };
 
-userdebug_or_eng(`
-  allow sensors diag_device:chr_file rw_file_perms;
-')
+rw_diag_device(sensors)
 
 qrtr_socket_create(sensors)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
@@ -37,4 +35,3 @@ r_dir_file(sensors, sysfs_soc)
 r_dir_file(sensors, sysfs_esoc)
 
 dontaudit sensors kernel:system { module_request };
-dontaudit sensors diag_device:chr_file rw_file_perms;

--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -20,9 +20,8 @@ allow sscrpcd mnt_vendor_file:dir { search open read };
 allow sscrpcd vendor_file:dir read;
 allow sscrpcd adsprpcd_file:dir read;
 
-allow sscrpcd sysfs_msm_subsys:dir { search open read };
-allow sscrpcd sysfs_msm_subsys:file { open read };
-allow sscrpcd sysfs_soc:dir search;
-allow sscrpcd sysfs_soc:file r_file_perms;
+r_dir_file(sscrpcd, sysfs_msm_subsys)
+r_dir_file(sscrpcd, sysfs_soc)
+r_dir_file(sscrpcd, sysfs_esoc)
 
 dontaudit sscrpcd kernel:system module_request;

--- a/vendor/te_macros
+++ b/vendor/te_macros
@@ -34,3 +34,15 @@ allow $1 self:qipcrtr_socket create_socket_perms_no_ioctl;
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allow $1 self:socket create_socket_perms;
 ')
+
+#####################################
+# rw_diag_device(domain)
+# Allow the specified domain rw_file_perms to diag_device
+# in userdebug or eng builds, donotaudit otherwise.
+define(`rw_diag_device', `
+userdebug_or_eng(`
+  allow $1 diag_device:chr_file rw_file_perms;
+')
+# Ignore in user builds
+dontaudit $1 diag_device:chr_file rw_file_perms;
+')


### PR DESCRIPTION
This cleans up access to diag_device and makes rules consistent across all services using it. Let me know if explicit file/dir permissions without **seemingly unrequested** ioctl/lock (perhaps map too) is desired.

The initial policy for `dpmQmiMgr` is included. `dpmd` will follow when it is more stable.