### PR TITLE
[WIP] Add and label qcrild service

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -63,6 +63,7 @@
 /odm/bin/pm-service                             u:object_r:per_mgr_exec:s0
 /odm/bin/pm-proxy                               u:object_r:per_proxy_exec:s0
 /odm/bin/pd-mapper                              u:object_r:pd_mapper_exec:s0
+/odm/bin/hw/qcrild                              u:object_r:qcrild_exec:s0
 /odm/bin/qmuxd                                  u:object_r:qmuxd_exec:s0
 /odm/bin/dataadpl                               u:object_r:adpl_exec:s0
 /odm/bin/dataqti                                u:object_r:qti_exec:s0

--- a/vendor/qcrild.te
+++ b/vendor/qcrild.te
@@ -1,0 +1,4 @@
+type qcrild, domain;
+type qcrild_exec, exec_type, vendor_file_type, file_type;
+
+init_daemon_domain(qcrild)


### PR DESCRIPTION
For @kholk ;)

---

QCRILD is a Qualcomm Radio Interface Layer (RIL)
implementation, added in Kernel 4.14 blobs v4 for recent
devices.

This is the initial policy, to be expanded.

Test: Kagura - `make selinux_policy` -> OK