### PR TITLE
qcrild: Label as rild

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -62,7 +62,7 @@
 /odm/bin/pm-service                             u:object_r:per_mgr_exec:s0
 /odm/bin/pm-proxy                               u:object_r:per_proxy_exec:s0
 /odm/bin/pd-mapper                              u:object_r:pd_mapper_exec:s0
-/odm/bin/hw/qcrild                              u:object_r:qcrild_exec:s0
+/odm/bin/hw/qcrild                              u:object_r:rild_exec:s0
 /odm/bin/qmuxd                                  u:object_r:qmuxd_exec:s0
 /odm/bin/qrtr-ns                                u:object_r:qrtr_exec:s0
 /odm/bin/qseecomd                               u:object_r:tee_exec:s0

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -27,6 +27,7 @@ vendor.peripheral.              u:object_r:vendor_peripheral_prop:s0
 vendor.qcom.adspup              u:object_r:vendor_device_prop:s0
 vendor.qcom.cdspup              u:object_r:vendor_device_prop:s0
 vendor.qcom.slpiup              u:object_r:vendor_device_prop:s0
+vendor.radio.                   u:object_r:vendor_radio_prop:s0
 vendor.rild.                    u:object_r:vendor_radio_prop:s0
 vendor.sys.keymaster.loaded     u:object_r:vendor_keymaster_prop:s0
 vendor.sys.listeners.           u:object_r:vendor_tee_listener_prop:s0

--- a/vendor/qcrild.te
+++ b/vendor/qcrild.te
@@ -1,4 +1,0 @@
-type qcrild, domain;
-type qcrild_exec, exec_type, vendor_file_type, file_type;
-
-init_daemon_domain(qcrild)

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -11,9 +11,7 @@ not_compatible_property(`
 set_prop(rild, vendor_radio_prop)
 set_prop(rild, vendor_net_prop)
 
-allow rild radio_vendor_data_file:dir create_dir_perms;
-allow rild radio_vendor_data_file:file create_file_perms;
-
+create_dir_file(rild, radio_vendor_data_file)
 # odm/radio/qcril_database/qcril.db
 allow rild vendor_file:file { ioctl lock };
 


### PR DESCRIPTION
Qcrild is the successor of rild. It:
- Needs roughly the same permissions as rild;
- Cannot add the same services as the rild domain;
- `rild' is an AOSP domain with sensible default rules that do not need
  to be duplicated in SODP policy.

Label it as rild for these reasons.

---

No other rild related denials are observed on Griffin DSDS (with a single SIM inserted). Cellular and mobile data work correctly.