### PR TITLE
TEMPORARY: rild: Transition from wrong qcrild_exec label to rild domain

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -21,3 +21,5 @@
   when kernel 4.14 is final. ioctl defines and macros can be removed as well.
 - b/aosp-keylayout: Remove once https://r.android.com/1140902 has landed in
   Android R
+- b/qcrild: Remove qcrild_exec label and rild domain transition when odm-v5 is
+  released

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -32,3 +32,13 @@ allow rild self:socket ioctl;
 allowxperm rild self:socket ioctl msm_sock_ipc_ioctls;
 
 hal_server_domain(rild, hal_secure_element)
+
+########### TEMPORARY ###########
+# b/qcrild:
+# Unfortunately ODM V4 is released with the wrong label on /odm/bin/hw/qcrild,
+# before we identified the issues of having a separate domain for legacy rild
+# and qcrild (see previous commits for more details). This re-adds that label
+# temporarily, and allows it to become the `rild' domain:
+type qcrild_exec, exec_type, vendor_file_type, file_type;
+domain_auto_trans(init, qcrild_exec, rild)
+######### END TEMPORARY #########


### PR DESCRIPTION
The qcrild labels and domain were reverted because this is not
compatible with the specific `rild` domain exposed by AOSP, and
add_hwservice explicitly disallows multiple domains from hosting the
same service (which would be the case with a concurrent `rild` and
`qcrild` domain). See previous commits for more details.

However, ODM V4 has already been released with this stray qcrild_exec
label. Re-add it and allow the executable to transition into the rild
domain.