### PR TITLE
[SEPOLICY] rild: Label and start data.iwlan::IIWlan service.

### DIFF
--- a/vendor/hwservice.te
+++ b/vendor/hwservice.te
@@ -3,6 +3,7 @@ type hal_imsrtp_hwservice,              hwservice_manager_type;
 type nxpese_hwservice,                  hwservice_manager_type;
 type nxpnfc_hwservice,                  hwservice_manager_type;
 type vnd_data_connection_hwservice,     hwservice_manager_type;
+type vnd_data_iwlan_hwservice,          hwservice_manager_type;
 type vnd_ims_radio_hwservice,           hwservice_manager_type;
 type vnd_qcrilhook_hwservice,           hwservice_manager_type;
 type vnd_qti_dpm_hwservice,             hwservice_manager_type;

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -15,6 +15,7 @@ vendor.qti.hardware.radio.uim::IUim                                     u:object
 vendor.qti.hardware.radio.lpa::IUimLpa                                  u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.radio.qtiradio::IQtiRadio                           u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.data.connection::IDataConnection                    u:object_r:vnd_data_connection_hwservice:s0
+vendor.qti.hardware.data.iwlan::IIWlan                                  u:object_r:vnd_data_iwlan_hwservice:s0
 # QTI HAL interfaces for display services:
 vendor.qti.hardware.display.mapper::IQtiMapper                          u:object_r:hal_graphics_mapper_hwservice:s0
 vendor.qti.hardware.display.allocator::IQtiAllocator                    u:object_r:hal_graphics_allocator_hwservice:s0

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -25,6 +25,7 @@ unix_socket_connect(rild, netmgrd, netmgrd)
 add_hwservice(rild, vnd_ims_radio_hwservice)
 add_hwservice(rild, vnd_qcrilhook_hwservice)
 add_hwservice(rild, vnd_data_connection_hwservice)
+add_hwservice(rild, vnd_data_iwlan_hwservice)
 
 qrtr_socket_create(rild)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final


### PR DESCRIPTION
The new qcrild wants to host the IIWlan interface.

Solves the following denial:
denied  { add } for interface=vendor.qti.hardware.data.iwlan::IIWlan
scontext=u:r:rild:s0 tcontext=u:object_r:default_android_hwservice:s0
tclass=hwservice_manager