### PR TITLE
[SEPOLICY] file_contexts: Update NFC node property to include all of pn5[0-9]+

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -26,7 +26,7 @@
 /dev/ramdump_.*                                 u:object_r:ramdump_device:s0
 /dev/sg[0-9]+                                   u:object_r:sg_device:s0
 /dev/sensors                                    u:object_r:sensors_device:s0
-/dev/pn54x                                      u:object_r:nfc_device:s0
+/dev/pn5[0-9]+                                  u:object_r:nfc_device:s0
 /dev/smem_log                                   u:object_r:smem_log_device:s0
 /dev/fingerprint                                u:object_r:fingerprint_device:s0
 /dev/dri/card0                                  u:object_r:graphics_device:s0


### PR DESCRIPTION
Kumano uses a new driver that names its node /dev/pn553. To prevent
clashes in the future, label anything in the pn5 range.