### PR TITLE
[DONOTMERGE] [R] Minor: sysfs_mac_address, perfprofd removal

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -12,6 +12,7 @@ type sysfs_graphics, sysfs_type, fs_type;
 type sysfs_input_control, sysfs_type, fs_type;
 type sysfs_input_name, sysfs_type, fs_type;
 type sysfs_irq, sysfs_type, fs_type;
+type sysfs_mac_address, sysfs_type, fs_type;
 type sysfs_mdss_mdp_caps, sysfs_type, fs_type;
 type sysfs_mmc, sysfs_type, fs_type;
 type sysfs_msm_subsys, sysfs_type, fs_type;

--- a/vendor/system_app.te
+++ b/vendor/system_app.te
@@ -23,9 +23,6 @@ binder_call(system_app, per_mgr)
 binder_call(system_app, wificond)
 binder_call(system_app, update_engine)
 
-# This is a neverallow anyways, so ignore it
-dontaudit system_app perfprofd:binder call;
-
 allow system_app self:netlink_kobject_uevent_socket { bind create read setopt };
 
 allow system_app fs_bpf:dir search;


### PR DESCRIPTION
**DO NOT MERGE:** The `sysfs_mac_address` type declaration would throw a build error if merged on current Q master.

Minor adaptation to current master/R.

`sysfs_mac_address` was removed, but we are still using it

`perfprofd` is gone entirely.