### PR TITLE
file_context: Fix NFC node once again

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -26,7 +26,7 @@
 /dev/ramdump_.*                                 u:object_r:ramdump_device:s0
 /dev/sg[0-9]+                                   u:object_r:sg_device:s0
 /dev/sensors                                    u:object_r:sensors_device:s0
-/dev/pn5[0-9]+                                  u:object_r:nfc_device:s0
+/dev/pn5[0-9x]+                                 u:object_r:nfc_device:s0
 /dev/smem_log                                   u:object_r:smem_log_device:s0
 /dev/fingerprint                                u:object_r:fingerprint_device:s0
 /dev/dri/card0                                  u:object_r:graphics_device:s0


### PR DESCRIPTION
The device is named "pn54x" for legacy devices, which wasn't being caught by the number-only regex.

Obligatory proof:
`avc: denied { read write } for comm="nfc@1.2-service" name="pn54x" dev="tmpfs" ino=13934 scontext=u:r:hal_nfc_default:s0 tcontext=u:object_r:device:s0 tclass=chr_file`