### PR TITLE
seapp_contexts: qcrilam runs as normal app user now

### DIFF
--- a/vendor/seapp_contexts
+++ b/vendor/seapp_contexts
@@ -1,7 +1,5 @@
-# To assign a custom domain to system-level app, it needs to be a priv-app.
-# Otherwise it will stay a platform_app regardless of the domain specified here.
 user=system seinfo=platform name=com.sony.timekeep domain=timekeep_app type=app_data_file
-user=system seinfo=platform name=com.sony.qcrilam domain=qcrilam_app type=app_data_file
+user=_app seinfo=platform name=com.sony.qcrilam domain=qcrilam_app type=app_data_file
 # Why app_data_file and not system_app_data_file?
 # Because some daemon needs access to /data/data/com.sony.{timekeep,qcrilam}
 # This happens with system_app_data_file:


### PR DESCRIPTION
https://github.com/sonyxperiadev/QcRilAm/pull/7
QcRilAm has been updated to run as normal user rather than sharing
everything with the system user. This means that user=system doesn't
match, the app receives the wrong context and everything falls apart.
Update it to _app to match it running as uX_aYYY like any other app.

Also remove the comment which doesn't seem applicable anymore. There are
multiple matching rules involved in the process and priv-app is not a
requirement:
https://github.com/sonyxperiadev/QcRilAm/commit/4a4608a8982ffc5d2612c9da4e20acb635e10061#diff-3ae6be565f1e33e90e0b11f768de1f6c
QcRilAm is not a priv-app anymore for some time. If matching against
such strict matching is really required, use isPrivApp=true/false.