### PR TITLE
[SEPOLICY] Oem-v7 part1: dpm, adpl, qti, gnss

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ See `LICENSE.md`.
 3. `hal_server_domain()` and equivalents
 5. `typeattribute` violation declarations
 6. `binder_use()` and equivalents
-7. `binder_call()` and equivalents
-8. `add_service()` and equivalents
+   `get_prop(..., hwservicemanager_prop)` goes here too
+7. `add_service()` and equivalents
+8. `binder_call()`, finding services and equivalents
 9. Miscellaneous things like `wakelock_use()` and `capability`
 10. `get/set_prop()`
 11. `unix_socket_connect()` and other socket stuff

--- a/vendor/adpl.te
+++ b/vendor/adpl.te
@@ -2,3 +2,17 @@ type adpl, domain;
 type adpl_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(adpl)
+
+set_prop(adpl, ctl_stop_prop)
+
+allow adpl self:qipcrtr_socket create_socket_perms_no_ioctl;
+allow adpl adpl_dpm_uds_socket:sock_file write;
+
+allow adpl dpl_ctl_device:chr_file rw_file_perms;
+allow adpl ipa_odl_ctl_device:chr_file rw_file_perms;
+
+rw_diag_device(adpl)
+
+r_dir_file(adpl, sysfs_esoc)
+r_dir_file(adpl, sysfs_msm_subsys)
+r_dir_file(adpl, sysfs_soc)

--- a/vendor/device.te
+++ b/vendor/device.te
@@ -1,7 +1,9 @@
 type avtimer_device, dev_type;
 type bt_device, dev_type;
 type diag_device, dev_type, mlstrustedobject;
+type dpl_ctl_device, dev_type;
 type ipa_dev, dev_type;
+type ipa_odl_ctl_device, dev_type;
 type latency_device, dev_type;
 type modem_block_device, dev_type;
 type persist_block_device, dev_type;

--- a/vendor/dpmd.te
+++ b/vendor/dpmd.te
@@ -1,4 +1,27 @@
 type dpmd, domain;
 type dpmd_exec, exec_type, vendor_file_type, file_type;
 
+net_domain(dpmd)
 init_daemon_domain(dpmd)
+
+hwbinder_use(dpmd)
+get_prop(dpmd, hwservicemanager_prop)
+
+# Allow to find and use com.qualcomm.qti.dpmd.api::IdpmQmi
+allow dpmd vnd_qti_dpm_hwservice:hwservice_manager find;
+
+# Allow to talk to IdpmQmi over binder
+binder_call(dpmd, dpmqmimgr)
+
+# Register timerfd
+allow dpmd self:capability2 wake_alarm;
+
+# For netutils to be able to write their stdout stderr to the pipes opened by dpmd
+allow netutils_wrapper dpmd:fd use;
+# allow netutils_wrapper dpmd:fifo_file { getattr read write append };
+# allow netutils_wrapper dpmd:file r_file_perms;
+allow netutils_wrapper dpmd:unix_stream_socket { read write };
+
+rw_diag_device(dpmd)
+
+allow dpmd proc_net:file rw_file_perms;

--- a/vendor/dpmqmimgr.te
+++ b/vendor/dpmqmimgr.te
@@ -10,5 +10,6 @@ add_hwservice(dpmqmimgr, vnd_qti_dpm_hwservice)
 
 allow dpmqmimgr self:qipcrtr_socket create_socket_perms_no_ioctl;
 
-r_dir_file(dpmqmimgr, sysfs_msm_subsys)
 r_dir_file(dpmqmimgr, sysfs_esoc)
+r_dir_file(dpmqmimgr, sysfs_msm_subsys)
+r_dir_file(dpmqmimgr, sysfs_soc)

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -47,6 +47,7 @@ type irqbalance_socket, file_type;
 type netmgrd_socket, file_type;
 type powerhal_socket, file_type;
 type qmuxd_socket, file_type;
+type qti_dpm_uds_socket, file_type;
 type tad_socket, file_type;
 type ucommsvr_socket, file_type;
 
@@ -74,6 +75,7 @@ type audio_vendor_data_file, file_type, data_file_type;
 type bluetooth_vendor_data_file, file_type, data_file_type;
 type camera_vendor_data_file, file_type, data_file_type;
 type cashsvr_vendor_data_file, file_type, data_file_type;
+type dataqti_vendor_data_file, file_type, data_file_type;
 type display_vendor_data_file, file_type, data_file_type;
 type ipa_vendor_data_file, file_type, data_file_type;
 type location_vendor_data_file, file_type, data_file_type;

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -39,6 +39,7 @@ type debugfs_rpm, debugfs_type, fs_type;
 type debugfs_wlan, debugfs_type, fs_type;
 
 type adsprpcd_file, file_type, vendor_file_type, mlstrustedobject;
+type adpl_dpm_uds_socket, file_type;
 type cashsvr_socket, file_type;
 type ims_socket, file_type;
 type ipacm_socket, file_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -41,6 +41,7 @@
 /dev/socket/qmux_gps(/.*)?                      u:object_r:qmuxd_socket:s0
 /dev/socket/qmux_nfc(/.*)?                      u:object_r:qmuxd_socket:s0
 /dev/socket/qmux_radio(/.*)?                    u:object_r:qmuxd_socket:s0
+/dev/socket/qti_dpm_uds_file                    u:object_r:qti_dpm_uds_socket:s0
 /dev/socket/msm_irqbalance                      u:object_r:irqbalance_socket:s0
 /dev/socket/netmgr(/.*)?                        u:object_r:netmgrd_socket:s0
 /dev/socket/powerhal(/.*)?                      u:object_r:powerhal_socket:s0
@@ -209,6 +210,7 @@
 /data/vendor/bluetooth(/.*)?           u:object_r:bluetooth_vendor_data_file:s0
 /data/vendor/camera(/.*)?              u:object_r:camera_vendor_data_file:s0
 /data/vendor/cashsvr(/.*)?             u:object_r:cashsvr_vendor_data_file:s0
+/data/vendor/dataqti(/.*)?             u:object_r:dataqti_vendor_data_file:s0
 /data/vendor/display(/.*)?             u:object_r:display_vendor_data_file:s0
 /data/vendor/ipa(/.*)?                 u:object_r:ipa_vendor_data_file:s0
 /data/vendor/location(/.*)?            u:object_r:location_vendor_data_file:s0

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -1,6 +1,7 @@
 # dev nodes
 /dev/btpower                                    u:object_r:bt_device:s0
 /dev/diag                                       u:object_r:diag_device:s0
+/dev/dpl_ctrl                                   u:object_r:dpl_ctl_device:s0
 /dev/kgsl-3d0                                   u:object_r:gpu_device:s0
 /dev/rtc0                                       u:object_r:rtc_device:s0
 /dev/smd.*                                      u:object_r:smd_device:s0
@@ -8,6 +9,7 @@
 /dev/ttyHS1                                     u:object_r:serial_device:s0
 /dev/ttyMSM0                                    u:object_r:console_device:s0
 /dev/ipa                                        u:object_r:ipa_dev:s0
+/dev/ipa_odl_ctl                                u:object_r:ipa_odl_ctl_device:s0
 /dev/wwan_ioctl                                 u:object_r:ipa_dev:s0
 /dev/ipaNatTable                                u:object_r:ipa_dev:s0
 /dev/cpu_dma_latency                            u:object_r:latency_device:s0
@@ -33,6 +35,7 @@
 /dev/wlan                                       u:object_r:wlan_device:s0
 
 # dev socket nodes
+/dev/socket/adpl_cmd_uds_file                   u:object_r:adpl_dpm_uds_socket:s0
 /dev/socket/qmux_audio(/.*)?                    u:object_r:qmuxd_socket:s0
 /dev/socket/qmux_bluetooth(/.*)?                u:object_r:qmuxd_socket:s0
 /dev/socket/qmux_gps(/.*)?                      u:object_r:qmuxd_socket:s0

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -53,8 +53,8 @@
 /odm/bin/adpl                                   u:object_r:adpl_exec:s0
 /odm/bin/adsprpcd                               u:object_r:adsprpcd_exec:s0
 /odm/bin/cdsprpcd                               u:object_r:cdsprpcd_exec:s0
-/odm/bin/dpmd                                   u:object_r:dpmd_exec:s0
 /odm/bin/dpmQmiMgr                              u:object_r:dpmqmimgr_exec:s0
+/odm/bin/dpmd                                   u:object_r:dpmd_exec:s0
 /odm/bin/ims_rtp_daemon                         u:object_r:hal_imsrtp_exec:s0
 /odm/bin/imsdatadaemon                          u:object_r:ims_exec:s0
 /odm/bin/imsqmidaemon                           u:object_r:ims_exec:s0

--- a/vendor/hal_gnss_qti.te
+++ b/vendor/hal_gnss_qti.te
@@ -9,6 +9,8 @@ r_dir_file(hal_gnss_qti, sysfs_esoc)
 
 vndbinder_use(hal_gnss_qti)
 
+hal_client_domain(hal_gnss_qti, hal_health)
+
 allow hal_gnss_qti sysfs_soc:dir r_dir_perms;
 allow hal_gnss_qti sysfs_soc:file r_file_perms;
 allow hal_gnss_qti qmuxd_socket:dir w_dir_perms;

--- a/vendor/qti.te
+++ b/vendor/qti.te
@@ -2,3 +2,17 @@ type qti, domain;
 type qti_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(qti)
+
+allow qti qti_dpm_uds_socket:sock_file write;
+allow qti self:qipcrtr_socket create_socket_perms_no_ioctl;
+
+allow qti dpl_ctl_device:chr_file rw_file_perms;
+allow qti rmnet_device:chr_file rw_file_perms;
+
+r_dir_file(qti, sysfs_esoc)
+r_dir_file(qti, sysfs_msm_subsys)
+r_dir_file(qti, sysfs_soc)
+
+rw_diag_device(qti)
+
+r_dir_file(qti, dataqti_vendor_data_file)


### PR DESCRIPTION
A rather small patchset providing the initial policy for new services: dpm, (data)adpl and (data)qti. Following up with small fixes to `dpmQmiMgr` and `GNSS` 2.0.
Finally a small reordering in the README:
> Specifying what the domain exposes to the rest of the system before listing what it "needs" from other services seems like a more logical approach.

## TODO:
dpm wants a bit too much:
```
denied { dac_override } for comm="dpmd" capability=1 scontext=u:r:dpmd:s0 tcontext=u:r:dpmd:s0 tclass=capability
denied { setuid } for comm="dpmd" capability=7 scontext=u:r:dpmd:s0 tcontext=u:r:dpmd:s0 tclass=capability
```
The service _seems_ to run fine without, but more investigation is needed (these generally mean borked `open()` flags of readonly files etc).

Please review thoroughly before merging!