### PR TITLE
[SEPOLICY] Remove AOSP-duplicates for charger and hal_health_default

### DIFF
--- a/vendor/charger.te
+++ b/vendor/charger.te
@@ -1,4 +1,3 @@
 allow charger device:dir r_dir_perms;
 allow charger kernel:system syslog_read;
 allow charger sysfs_msm_subsys:file w_file_perms;
-allow charger sysfs_batteryinfo:file r_file_perms;

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -24,7 +24,6 @@ type sysfs_soc, sysfs_type, fs_type;
 type sysfs_system_sleep_stats, sysfs_type, fs_type;
 type sysfs_timestamp_switch, sysfs_type, fs_type;
 type sysfs_tof_sensor, fs_type, sysfs_type;
-type sysfs_usb_supply, sysfs_type, fs_type;
 type sysfs_wlan_power_stats, fs_type, sysfs_type;
 
 type debugfs_clk, debugfs_type, fs_type;

--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -1,8 +1,5 @@
 # Custom Sony health HAL
 
-# Register timerfd to periodically check (battery) health
-allow hal_health_default self:capability2 wake_alarm;
-
 # Resolve path in /mnt/vendor/
 allow hal_health_default mnt_vendor_file:dir search;
 # Write battery cycles and capacity to /{mnt/vendor/}persist/battery/

--- a/vendor/hal_health_default.te
+++ b/vendor/hal_health_default.te
@@ -8,7 +8,6 @@ allow hal_health_default persist_battery_file:file create_file_perms;
 # Resolve the underlying path of /sys/class/power_supply/battery/
 # and traverse /persist/ paths
 allow hal_health_default { sysfs_msm_subsys persist_file }:dir search;
-allow hal_health_default sysfs_usb_supply:file r_file_perms;
 # Read or restore battery statistics
 allow hal_health_default sysfs_batteryinfo:file rw_file_perms;
 # Read storage stats and emmc health


### PR DESCRIPTION
These lines have "recently" been added to AOSP rules, no need to redeclare them anymore :smile: 

(Note that this policy was written well before those commits in AOSP were even made)

Requires the following PRs to be merged first:
https://github.com/sonyxperiadev/device-sony-nile/pull/109
https://github.com/sonyxperiadev/device-sony-ganges/pull/30
https://github.com/sonyxperiadev/device-sony-seine/pull/1

Tested on Mermaid DSDS, no new denials show up.