### PR TITLE
[SEPOLICY] Remove labeling contexts for removed rootfs symlinks

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -226,9 +226,6 @@
 
 # TODO: Remove them once no need to maintain the backward compatibility. (b/111219177)
 /persist                             u:object_r:rootfs:s0
-/firmware                            u:object_r:rootfs:s0
-/bt_firmware                         u:object_r:rootfs:s0
-/dsp                                 u:object_r:rootfs:s0
 
 # adsp firmware
 /(system/vendor|vendor|odm)/lib/rfsa/adsp(/.*)?          u:object_r:adsprpcd_file:s0

--- a/vendor/hal_fingerprint_default.te
+++ b/vendor/hal_fingerprint_default.te
@@ -1,10 +1,6 @@
 r_dir_file(hal_fingerprint_default, vendor_firmware_file)
 r_dir_rw_file(hal_fingerprint_default, sysfs_fingerprint)
 
-# TODO(b/36764215): remove this file when the generic system image
-# no longer has these directories. They are specific to QCOM.
-r_dir_file(hal_fingerprint_default, firmware_file)
-
 allow hal_fingerprint_default tee_device:file rw_file_perms;
 allow hal_fingerprint_default tee_device:chr_file rw_file_perms;
 allow hal_fingerprint_default fingerprint_device:chr_file rw_file_perms;

--- a/vendor/ueventd.te
+++ b/vendor/ueventd.te
@@ -5,7 +5,16 @@ typeattribute ueventd data_between_core_and_vendor_violators;
 r_dir_file(ueventd, vendor_firmware_file)
 r_dir_file(ueventd, persist_file)
 r_dir_file(ueventd, wifi_vendor_data_file)
-allow ueventd firmware_file:lnk_file read;
+
+# The following line is here for posterity and grepping reasons only.
+# GSIs still ship with this label on /firmware, which is marked as bug
+# b/36764215 over at AOSP. The symlink should not be used and all our
+# platforms have ueventd firmware_directories extended in
+# /vendor/uevent.rc to direct to /vendor/firmware_mnt/image/, yet
+# /firwmare is searched first due to:
+# https://android.googlesource.com/platform/system/core/+/android-10.0.0_r33/rootdir/ueventd.rc#1
+# Hide this denial as any use of the link is misleading and wrong:
+dontaudit ueventd firmware_file:lnk_file read;
 
 allow ueventd {
     { sysfs_type - usermodehelper }


### PR DESCRIPTION
Drop `rootfs` labeling for `/firmware`, `/dsp` and `/bt_firmware`, which are all gone now.

Also partially revert the previous commit that grants access to an alternate `/firmware` label as well, which was intended to be superseded by migrating everything to `/vendor/firmware_mnt` entirely. But there's a case to be made for these changes, as `/firmware` still exists on most GSIs and is scanned first before our `/vendor/firmware_mnt/image/` is checked. This results in misleading permission denials.

@ix5 I started indifferent, but am at this point biased towards making it a `dontaudit` entirely. My reasoning to hide it:
- We all build and test our devices without this `/firmware` link now. If something breaks we will notice;
- If something can't find its firmware the denial will not be the only error. And it is misleading anyway since the link - again - should not be used: `/vendor/firmware_mnt/image/` is added to the path now and thus makes no difference;
- This label is restricted to GSIs, and will thus not be seen by many. I [initially made a point](https://github.com/sonyxperiadev/device-sony-sepolicy/commit/00ad9b3e53ed51b4fe38b6afc50ad168482d1cd3) to have it remind us periodically, but that's moot since none of the active sepolicy contributors run a GSI.