### PR TITLE
[SEPOLICY] Declare services and apps for modem switcher

### DIFF
--- a/vendor/hal_miscta_default.te
+++ b/vendor/hal_miscta_default.te
@@ -1,2 +1,13 @@
+type hal_miscta_default, domain;
 type hal_miscta_default_exec, exec_type, file_type, vendor_file_type;
 
+init_daemon_domain(hal_miscta_default)
+
+hwbinder_use(hal_miscta_default)
+add_hwservice(hal_miscta_default, vnd_somc_miscta_hwservice)
+
+allow hal_miscta_default hidl_memory_hwservice:hwservice_manager find;
+
+get_prop(hal_miscta_default, hwservicemanager_prop)
+
+unix_socket_connect(hal_miscta_default, tad, tad)

--- a/vendor/hal_modemsw_default.te
+++ b/vendor/hal_modemsw_default.te
@@ -1,2 +1,16 @@
+type hal_modemsw_default, domain;
 type hal_modemsw_default_exec, exec_type, file_type, vendor_file_type;
 
+init_daemon_domain(hal_modemsw_default)
+
+hwbinder_use(hal_modemsw_default)
+add_hwservice(hal_modemsw_default, vnd_somc_modemswitcher_hwservice)
+
+get_prop(hal_modemsw_default, hwservicemanager_prop)
+get_prop(hal_modemsw_default, vendor_radio_prop)
+
+allow hal_modemsw_default self:qipcrtr_socket create_socket_perms_no_ioctl;
+
+r_dir_file(hal_modemsw_default, sysfs_esoc)
+r_dir_file(hal_modemsw_default, sysfs_msm_subsys)
+r_dir_file(hal_modemsw_default, sysfs_soc)

--- a/vendor/hwservice.te
+++ b/vendor/hwservice.te
@@ -10,3 +10,4 @@ type vnd_qti_dpm_hwservice,             hwservice_manager_type;
 type vnd_qti_ims_callinfo_hwservice,    hwservice_manager_type;
 type vnd_qti_imscms_hwservice,          hwservice_manager_type;
 type vnd_qti_uce_hwservice,             hwservice_manager_type;
+type vnd_somc_miscta_hwservice,         hwservice_manager_type;

--- a/vendor/hwservice.te
+++ b/vendor/hwservice.te
@@ -11,3 +11,4 @@ type vnd_qti_ims_callinfo_hwservice,    hwservice_manager_type;
 type vnd_qti_imscms_hwservice,          hwservice_manager_type;
 type vnd_qti_uce_hwservice,             hwservice_manager_type;
 type vnd_somc_miscta_hwservice,         hwservice_manager_type;
+type vnd_somc_modemswitcher_hwservice,  hwservice_manager_type;

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -22,3 +22,5 @@ vendor.qti.hardware.display.mapper::IQtiMapper                          u:object
 vendor.qti.hardware.display.allocator::IQtiAllocator                    u:object_r:hal_graphics_allocator_hwservice:s0
 # QTI DPM:
 com.qualcomm.qti.dpm.api::IdpmQmi                                       u:object_r:vnd_qti_dpm_hwservice:s0
+# SoMC modem switcher:
+vendor.somc.hardware.miscta::IMisctaGlobal                              u:object_r:vnd_somc_miscta_hwservice:s0

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -9,11 +9,12 @@ vendor.qti.imsrtpservice::IRTPService                                   u:object
 # HIDL interface for com.sony.QcRilAm
 vendor.qti.hardware.radio.am::IQcRilAudio                               u:object_r:vnd_qcrilhook_hwservice:s0
 vendor.qti.hardware.radio.ims::IImsRadio                                u:object_r:vnd_ims_radio_hwservice:s0
+vendor.qti.hardware.radio.lpa::IUimLpa                                  u:object_r:hal_telephony_hwservice:s0
+vendor.qti.hardware.radio.qcrilhook::IQtiOemHook                        u:object_r:hal_telephony_hwservice:s0
+vendor.qti.hardware.radio.qtiradio::IQtiRadio                           u:object_r:hal_telephony_hwservice:s0
+vendor.qti.hardware.radio.uim::IUim                                     u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.radio.uim_remote_client::IUimRemoteServiceClient    u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.radio.uim_remote_server::IUimRemoteServiceServer    u:object_r:hal_telephony_hwservice:s0
-vendor.qti.hardware.radio.uim::IUim                                     u:object_r:hal_telephony_hwservice:s0
-vendor.qti.hardware.radio.lpa::IUimLpa                                  u:object_r:hal_telephony_hwservice:s0
-vendor.qti.hardware.radio.qtiradio::IQtiRadio                           u:object_r:hal_telephony_hwservice:s0
 vendor.qti.hardware.data.connection::IDataConnection                    u:object_r:vnd_data_connection_hwservice:s0
 vendor.qti.hardware.data.iwlan::IIWlan                                  u:object_r:vnd_data_iwlan_hwservice:s0
 # QTI HAL interfaces for display services:

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -24,3 +24,4 @@ vendor.qti.hardware.display.allocator::IQtiAllocator                    u:object
 com.qualcomm.qti.dpm.api::IdpmQmi                                       u:object_r:vnd_qti_dpm_hwservice:s0
 # SoMC modem switcher:
 vendor.somc.hardware.miscta::IMisctaGlobal                              u:object_r:vnd_somc_miscta_hwservice:s0
+vendor.somc.hardware.modemswitcher::IModemSwitcher                      u:object_r:vnd_somc_modemswitcher_hwservice:s0

--- a/vendor/init.te
+++ b/vendor/init.te
@@ -17,6 +17,7 @@ allow init proc_irq:file rw_file_perms;
 
 # Mount and read/write to devices
 allow init device:dir { mounton rw_dir_perms };
+allow init oemfs:dir mounton;
 # /dev/cpuset/*
 allow init device:file rw_file_perms;
 

--- a/vendor/modemconfig_app.te
+++ b/vendor/modemconfig_app.te
@@ -1,0 +1,21 @@
+type modemconfig_app, domain;
+
+app_domain(modemconfig_app)
+
+# Needed to get access to /data/data/com.sony.modemconfig
+# Only getattr and search are requested since modemconfig does not write to its own directory
+# /data/data/com.sony.modemconfig only has two empty subdirs
+dontaudit modemconfig_app app_data_file:dir { getattr search };
+
+# Acccess to its own service and broadcasts
+allow modemconfig_app activity_service:service_manager find;
+
+# Access telephony.registry service
+allow modemconfig_app registry_service:service_manager find;
+
+# Access isub service
+allow modemconfig_app radio_service:service_manager find;
+
+set_prop(modemconfig_app, vendor_somc_cust_prop)
+
+allow modemconfig_app cgroup:file w_file_perms;

--- a/vendor/modemsw.te
+++ b/vendor/modemsw.te
@@ -3,3 +3,17 @@ type modemsw_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(modemsw)
 
+hwbinder_use(modemsw)
+
+# Access miscta
+allow modemsw vnd_somc_miscta_hwservice:hwservice_manager find;
+binder_call(modemsw, hal_miscta_default)
+# Access modemsw service
+allow modemsw vnd_somc_modemswitcher_hwservice:hwservice_manager find;
+binder_call(modemsw, hal_modemsw_default)
+# Access allocator
+hal_client_domain(modemsw, hal_allocator)
+
+get_prop(modemsw, hwservicemanager_prop)
+get_prop(modemsw, vendor_somc_cust_prop)
+set_prop(modemsw, vendor_somc_modemswitcher_prop)

--- a/vendor/property.te
+++ b/vendor/property.te
@@ -16,6 +16,8 @@ type vendor_net_prop, property_type;
 type vendor_peripheral_prop, property_type;
 type vendor_powerhal_prop, property_type;
 type vendor_radio_prop, property_type;
+type vendor_somc_cust_prop, property_type;
+type vendor_somc_modemswitcher_prop, property_type;
 type vendor_tee_listener_prop, property_type;
 type vendor_timekeep_prop, property_type;
 type vendor_usb_config_prop, property_type;

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -35,3 +35,9 @@ vendor.usb.                     u:object_r:vendor_usb_prop:s0
 vendor.usb.config               u:object_r:vendor_usb_config_prop:s0
 vendor.wlan.                    u:object_r:vendor_wifi_prop:s0
 wc_transport.                   u:object_r:wc_prop:s0
+
+# Modemswitcher props. Not in the above list as they are about to be changed.
+persist.somc.cust.              u:object_r:vendor_somc_cust_prop:s0
+persist.somc.modemswitcher.     u:object_r:vendor_somc_modemswitcher_prop:s0
+persist.vendor.somc.            u:object_r:vendor_somc_cust_prop:s0
+sony.modemswitcher.             u:object_r:vendor_somc_modemswitcher_prop:s0

--- a/vendor/seapp_contexts
+++ b/vendor/seapp_contexts
@@ -1,5 +1,6 @@
 user=system seinfo=platform name=com.sony.timekeep domain=timekeep_app type=app_data_file
 user=_app seinfo=platform name=com.sony.qcrilam domain=qcrilam_app type=app_data_file
+user=_app seinfo=platform name=com.sony.opentelephony.modemconfig isPrivApp=true domain=modemconfig_app type=app_data_file
 # Why app_data_file and not system_app_data_file?
 # Because some daemon needs access to /data/data/com.sony.{timekeep,qcrilam}
 # This happens with system_app_data_file:


### PR DESCRIPTION
Provide a baseline policy for modemflasher, including broken vendor props and all.

Needs some thorough review and a test for completeness on multiple platforms.
