### PR TITLE
[SEPOLICY] tee: Label and grant access to new /data/vendor/tzstorage folder

### DIFF
--- a/vendor/file.te
+++ b/vendor/file.te
@@ -88,6 +88,7 @@ type nfc_vendor_data_file, file_type, data_file_type;
 type radio_vendor_data_file, file_type, data_file_type, mlstrustedobject;
 type sensors_vendor_data_file, file_type, data_file_type;
 type timekeep_vendor_data_file, file_type, data_file_type;
+type tzstorage_vendor_data_file, file_type, data_file_type;
 type wifi_vendor_data_file, file_type, data_file_type;
 
 type egistec_misc_data_file, file_type, data_file_type, core_data_file_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -219,6 +219,7 @@
 /data/vendor/radio(/.*)?               u:object_r:radio_vendor_data_file:s0
 /data/vendor/sensors(/.*)?             u:object_r:sensors_vendor_data_file:s0
 /data/vendor/time(/.*)?                u:object_r:timekeep_vendor_data_file:s0
+/data/vendor/tzstorage(/.*)?           u:object_r:tzstorage_vendor_data_file:s0
 /data/vendor/wifi(/.*)?                u:object_r:wifi_vendor_data_file:s0
 
 # Misc data files (WARNING: violates core<->vendor boundaries)

--- a/vendor/tee.te
+++ b/vendor/tee.te
@@ -15,6 +15,8 @@ allowxperm tee rpmb_block_device:blk_file ioctl MMC_IOC_CMD;
 allow tee ssd_block_device:blk_file rw_file_perms;
 allow tee sg_device:chr_file { rw_file_perms setattr };
 
+rw_dir_file(tee, tzstorage_vendor_data_file)
+
 allow tee persist_file:dir r_dir_perms;
 allow tee persist_data_file:dir create_dir_perms;
 allow tee persist_data_file:file create_file_perms;


### PR DESCRIPTION
A new configuration for the GP FS listener [1] MAY use/move some files
in /data/vendor/tzstorage (to prevent non-vendor files ending up in
system folders such as /data/{system,misc}. Grant full readwrite access
to these folders by qseecomd.

    qseecomd: avc: denied { read } for name="tzstorage" dev="sda73" scontext=u:r:tee:s0 tcontext=u:object_r:vendor_data_file:s0 tclass=dir

[1]: https://github.com/sonyxperiadev/device-sony-common/commit/547687c20fb2d5d2c763d4fd7c929302da269973
