### PR TITLE
[SEPOLICY] adsprpcd updates and hw module labels for Seine

### DIFF
--- a/vendor/adsprpcd.te
+++ b/vendor/adsprpcd.te
@@ -9,5 +9,7 @@ allow adsprpcd qdsp_device:chr_file r_file_perms;
 allow adsprpcd system_file:dir r_dir_perms;
 allow adsprpcd vendor_file:dir r_dir_perms;
 
+r_dir_file(adsprpcd, sysfs_soc)
+
 # For reading dir/files on /dsp
 r_dir_file(adsprpcd, adsprpcd_file)

--- a/vendor/adsprpcd.te
+++ b/vendor/adsprpcd.te
@@ -13,3 +13,10 @@ r_dir_file(adsprpcd, sysfs_soc)
 
 # For reading dir/files on /dsp
 r_dir_file(adsprpcd, adsprpcd_file)
+
+# For reading /mnt/vendor/
+allow adsprpcd mnt_vendor_file:dir r_dir_perms;
+# For reading /mnt/vendor/persist/
+allow adsprpcd persist_file:dir r_dir_perms;
+
+create_dir_file(adsprpcd, persist_sensors_file)

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -141,7 +141,7 @@
 #
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.msm89(52|96|98)\.so  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sdm(660|845)\.so     u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sm8150\.so           u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sm(8150|6125)\.so    u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqdMetaData(\.legacy)?\.so     u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqservice\.so                  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqdutils\.so                   u:object_r:same_process_hal_file:s0
@@ -150,7 +150,7 @@
 
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.msm89(52|96|98)\.so   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sdm(660|845)\.so      u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sm8150\.so            u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sm(8150|6125)\.so     u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.qcom\.so              u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libEGL_adreno\.so         u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libGLESv1_CM_adreno\.so   u:object_r:same_process_hal_file:s0


### PR DESCRIPTION
Label `gralloc` and `vulkan` HW modules for Seine/PDX201 (SM6125) and update `adsprcpd` with rw access to /mnt/vendor/persist/sensors.
