### PR TITLE
[SEPOLICY] audio: Allow access to IMisctaGlobal

### DIFF
--- a/vendor/hal_audio_default.te
+++ b/vendor/hal_audio_default.te
@@ -1,4 +1,6 @@
 hal_client_domain(hal_audio_default, hal_power)
+allow hal_audio_default vnd_somc_miscta_hwservice:hwservice_manager find;
+binder_call(hal_audio_default, hal_miscta_default)
 
 not_compatible_property(`
   get_prop(hal_audio_default, bluetooth_prop)


### PR DESCRIPTION
Update policy to allow connecting to IMisctaGlobal over binder, which
we recently switched to in [1]:

    avc:  denied  { find } for
    interface=vendor.somc.hardware.miscta::IMisctaGlobal
    sid=u:r:hal_audio_default:s0 pid=627
    scontext=u:r:hal_audio_default:s0
    tcontext=u:object_r:vnd_somc_miscta_hwservice:s0
    tclass=hwservice_manager
    avc: denied { call } for scontext=u:r:hal_audio_default:s0
    tcontext=u:r:hal_miscta_default:s0 tclass=binder

[1]: https://github.com/sonyxperiadev/vendor-qcom-opensource-audio-hal-primary-hal/pull/4
