### PR TITLE
[SEPOLICY] fastbootd: Allow flashing of recovery, dtbo and vbmeta block devices

### DIFF
--- a/vendor/fastbootd.te
+++ b/vendor/fastbootd.te
@@ -1,0 +1,7 @@
+recovery_only(`
+  allow fastbootd {
+    dtbo_block_device
+    recovery_block_device
+    vbmeta_block_device
+  }:blk_file { w_file_perms getattr ioctl };
+')


### PR DESCRIPTION
These block devices are not allowed to be flashed in AOSP policy but can be flashed from fastbootd.

This change requires the file nodes for them to be labeled properly in device repositories.
See seine: https://github.com/sonyxperiadev/device-sony-seine/pull/18