### PR TITLE
[SEPOLICY] Update the hvdcp policy

### DIFF
--- a/vendor/device.te
+++ b/vendor/device.te
@@ -27,3 +27,4 @@ type wlan_device, dev_type;
 type gpt_block_device, dev_type;
 type dtbo_block_device, dev_type;
 type vbmeta_block_device, dev_type;
+type hvdcp_opti_device, dev_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -33,6 +33,8 @@
 /dev/fingerprint                                u:object_r:fingerprint_device:s0
 /dev/dri/card0                                  u:object_r:graphics_device:s0
 /dev/wlan                                       u:object_r:wlan_device:s0
+/dev/qg                                         u:object_r:hvdcp_opti_device:s0
+/dev/qg_battery                                 u:object_r:hvdcp_opti_device:s0
 
 # dev socket nodes
 /dev/socket/adpl_cmd_uds_file                   u:object_r:adpl_dpm_uds_socket:s0

--- a/vendor/hvdcp_opti.te
+++ b/vendor/hvdcp_opti.te
@@ -15,6 +15,9 @@ allow hvdcp_opti self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl
 # Allow readwrite to /dev/qg{,_battery}
 allow hvdcp_opti hvdcp_opti_device:chr_file rw_file_perms;
 
+# Allow writing logs to kmsg
+allow hvdcp_opti kmsg_device:chr_file { w_file_perms getattr };
+
 # Access persist files
 allow hvdcp_opti mnt_vendor_file:dir search;
 allow hvdcp_opti persist_file:dir search;

--- a/vendor/hvdcp_opti.te
+++ b/vendor/hvdcp_opti.te
@@ -4,15 +4,18 @@ type hvdcp_opti_exec, exec_type, vendor_file_type, file_type;
 net_domain(hvdcp_opti)
 init_daemon_domain(hvdcp_opti)
 
-allow hvdcp_opti device:chr_file { getattr ioctl };
-allow hvdcp_opti init:unix_stream_socket connectto;
+# Misc features
+allow hvdcp_opti sysfs_wake_lock:file w_file_perms;
+allow hvdcp_opti self:capability2 { block_suspend wake_alarm };
+
+set_prop(hvdcp_opti, hvdcp_opti_prop)
+
+allow hvdcp_opti self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;
+
+# Access persist files
+allow hvdcp_opti mnt_vendor_file:dir search;
 allow hvdcp_opti persist_file:dir search;
 allow hvdcp_opti persist_hvdcp_file:dir search;
-allow hvdcp_opti property_socket:sock_file write;
-allow hvdcp_opti self:capability2 { block_suspend wake_alarm };
-allow hvdcp_opti self:netlink_kobject_uevent_socket { bind create getopt read setopt };
-allow hvdcp_opti sysfs_batteryinfo:dir search;
-allow hvdcp_opti sysfs_batteryinfo:file { getattr open read };
+
+r_dir_file(hvdcp_opti, sysfs_batteryinfo)
 allow hvdcp_opti sysfs_msm_subsys:dir search;
-allow hvdcp_opti sysfs_wake_lock:file { open write };
-allow hvdcp_opti vendor_default_prop:property_service set;

--- a/vendor/hvdcp_opti.te
+++ b/vendor/hvdcp_opti.te
@@ -12,6 +12,9 @@ set_prop(hvdcp_opti, hvdcp_opti_prop)
 
 allow hvdcp_opti self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;
 
+# Allow readwrite to /dev/qg{,_battery}
+allow hvdcp_opti hvdcp_opti_device:chr_file rw_file_perms;
+
 # Access persist files
 allow hvdcp_opti mnt_vendor_file:dir search;
 allow hvdcp_opti persist_file:dir search;

--- a/vendor/property.te
+++ b/vendor/property.te
@@ -1,4 +1,5 @@
 type camera_prop, property_type;
+type hvdcp_opti_prop, property_type;
 type keymaster_prop, property_type;
 type net_rmnet_prop, property_type;
 type qcom_ims_prop, property_type;

--- a/vendor/property_contexts
+++ b/vendor/property_contexts
@@ -5,6 +5,7 @@ persist.vendor.bt.              u:object_r:vendor_bluetooth_prop:s0
 persist.vendor.camera.          u:object_r:vendor_camera_prop:s0
 persist.vendor.cash.            u:object_r:vendor_cash_prop:s0
 persist.vendor.dispcal.         u:object_r:vendor_dispcal_prop:s0
+persist.vendor.hvdcp_opti.      u:object_r:hvdcp_opti_prop:s0
 persist.vendor.health.          u:object_r:vendor_health_prop:s0
 persist.vendor.ims.             u:object_r:qcom_ims_prop:s0
 persist.vendor.net.             u:object_r:vendor_net_prop:s0


### PR DESCRIPTION
Conver audit2allow rules to something sensible, turn generic labels (on the properties and `/dev/qg{,_battery}`) into specific ones, and allow the missing kmsg write.

Note that I couldn't see `allow hvdcp_opti init:unix_stream_socket connectto;` being used anywhere.
