### PR TITLE
[SEPOLICY] [RFC] Move all radio-related hwservices into the hal_telephony "binder domain"

### DIFF
--- a/BUGSs.md
+++ b/BUGSs.md
@@ -21,6 +21,4 @@
   when kernel 4.14 is final. ioctl defines and macros can be removed as well.
 - b/aosp-keylayout: Remove once https://r.android.com/1140902 has landed in
   Android R
-- b/qcrild: Remove qcrild_exec label and rild domain transition when odm-v5 is
-  released
 - b/36764215: Remove `firmware_file` compat once 64bit A/B GSIs stop shipping it

--- a/vendor/cnd.te
+++ b/vendor/cnd.te
@@ -3,13 +3,15 @@ type cnd_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(cnd)
 
+hwbinder_use(cnd)
+
+# Host all services in hal_telephony hwservice attribute group
+hal_server_domain(cnd, hal_telephony)
+
 allow cnd self:udp_socket create_socket_perms;
 allow cnd self:qipcrtr_socket create_socket_perms_no_ioctl;
 
-hwbinder_use(cnd)
 get_prop(cnd, hwservicemanager_prop)
-add_hwservice(cnd, vnd_data_linklatency_hwservice)
-add_hwservice(cnd, vnd_data_factory_hwservice)
 
 r_dir_file(cnd, sysfs_msm_subsys)
 r_dir_file(cnd, sysfs_soc)

--- a/vendor/hal_telephony.te
+++ b/vendor/hal_telephony.te
@@ -1,0 +1,4 @@
+hal_attribute_hwservice(hal_telephony, vnd_data_connection_hwservice)
+hal_attribute_hwservice(hal_telephony, vnd_data_iwlan_hwservice)
+hal_attribute_hwservice(hal_telephony, vnd_ims_radio_hwservice)
+hal_attribute_hwservice(hal_telephony, vnd_qcrilhook_hwservice)

--- a/vendor/hal_telephony.te
+++ b/vendor/hal_telephony.te
@@ -1,4 +1,6 @@
 hal_attribute_hwservice(hal_telephony, vnd_data_connection_hwservice)
+hal_attribute_hwservice(hal_telephony, vnd_data_factory_hwservice)
 hal_attribute_hwservice(hal_telephony, vnd_data_iwlan_hwservice)
+hal_attribute_hwservice(hal_telephony, vnd_data_linklatency_hwservice)
 hal_attribute_hwservice(hal_telephony, vnd_ims_radio_hwservice)
 hal_attribute_hwservice(hal_telephony, vnd_qcrilhook_hwservice)

--- a/vendor/qcrilam_app.te
+++ b/vendor/qcrilam_app.te
@@ -15,9 +15,7 @@ allow qcrilam_app audioserver_service:service_manager find;
 allow qcrilam_app radio_service:service_manager find;
 
 # Find the vendor.qti.hardware.radio.am::IQcRilAudio HIDL service
-allow qcrilam_app vnd_qcrilhook_hwservice:hwservice_manager find;
-
-# Interact with rild
-binder_call(qcrilam_app, rild)
+# And grant binder access to the host (`rild`)
+hal_client_domain(qcrilam_app, hal_telephony)
 
 allow qcrilam_app cgroup:file w_file_perms;

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -4,7 +4,6 @@ vndbinder_use(rild)
 hal_server_domain(rild, hal_telephony)
 
 binder_call(rild, per_mgr)
-binder_call(rild, qcrilam_app);
 
 allow rild per_mgr_service:service_manager find;
 

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -33,13 +33,3 @@ allow rild self:socket ioctl;
 allowxperm rild self:socket ioctl msm_sock_ipc_ioctls;
 
 hal_server_domain(rild, hal_secure_element)
-
-########### TEMPORARY ###########
-# b/qcrild:
-# Unfortunately ODM V4 is released with the wrong label on /odm/bin/hw/qcrild,
-# before we identified the issues of having a separate domain for legacy rild
-# and qcrild (see previous commits for more details). This re-adds that label
-# temporarily, and allows it to become the `rild' domain:
-type qcrild_exec, exec_type, vendor_file_type, file_type;
-domain_auto_trans(init, qcrild_exec, rild)
-######### END TEMPORARY #########

--- a/vendor/rild.te
+++ b/vendor/rild.te
@@ -1,5 +1,8 @@
 vndbinder_use(rild)
 
+# Host all services in hal_telephony hwservice attribute group
+hal_server_domain(rild, hal_telephony)
+
 binder_call(rild, per_mgr)
 binder_call(rild, qcrilam_app);
 
@@ -21,11 +24,6 @@ unix_socket_connect(rild, qmuxd, qmuxd)
 
 allow rild netmgrd_socket:dir search;
 unix_socket_connect(rild, netmgrd, netmgrd)
-
-add_hwservice(rild, vnd_ims_radio_hwservice)
-add_hwservice(rild, vnd_qcrilhook_hwservice)
-add_hwservice(rild, vnd_data_connection_hwservice)
-add_hwservice(rild, vnd_data_iwlan_hwservice)
 
 qrtr_socket_create(rild)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final


### PR DESCRIPTION
On seine we're observing the following:

    avc:  denied  { find } for interface=vendor.qti.hardware.data.iwlan::IIWlan sid=u:r:radio:s0 scontext=u:r:radio:s0 tcontext=u:object_r:vnd_data_iwlan_hwservice:s0 tclass=hwservice_manager
    avc:  denied  { find } for interface=vendor.qti.data.factory::IFactory sid=u:r:radio:s0 scontext=u:r:radio:s0 tcontext=u:object_r:vnd_data_factory_hwservice:s0 tclass=hwservice_manager

While we could explicitly allow `radio` to find these services, and consequently grant binder access back and forth between radio and the hosting domains (`rild` and `cnd` respectively), AOSP policy already has special macros and attributes in place to confine a triple of these parts:
- Client(s) for a specific service or group of services (`hal_client_domain`);
- Server(s) who are allowed to host that service (`hal_server_domain`);
- The actual service(s) (`hal_attribute_hwservice`).

`radio` is in the client domain of `hal_telephony` as per AOSP policy, and we can leverage that rather than creating a bunch of new attributes for our services. This PR switches all radio-related services over to this model. `rild` and `cnd` are servers, and all services are defined in `hal_telephony.te`. Now-superfluous rules such as `binder_call` between components has been replaced with `hal_client_domain`.

Note that this PR is **draft** and **request for comments**; changes and commits have to be cleaned up, be sure to read through inline comments for more information on this change. Let's discuss whether this is the right approach or we should go for more specific, less permissive rules (such as making isolated attribute groups to put our services in with `radio` and related domains clients).