### PR TITLE
[SEPOLICY] [R] app: Migrate service rules to app_api_service

### DIFF
--- a/vendor/modemconfig_app.te
+++ b/vendor/modemconfig_app.te
@@ -7,11 +7,8 @@ app_domain(modemconfig_app)
 # /data/data/com.sony.modemconfig only has two empty subdirs
 dontaudit modemconfig_app app_data_file:dir { getattr search };
 
-# Acccess to its own service and broadcasts
-allow modemconfig_app activity_service:service_manager find;
-
-# Access telephony.registry service
-allow modemconfig_app registry_service:service_manager find;
+# Access services that should be available to all apps
+allow modemconfig_app app_api_service:service_manager find;
 
 # Access isub service
 allow modemconfig_app radio_service:service_manager find;

--- a/vendor/qcrilam_app.te
+++ b/vendor/qcrilam_app.te
@@ -7,8 +7,9 @@ app_domain(qcrilam_app)
 # /data/data/com.sony.qcrilam only has two empty subdirs
 dontaudit qcrilam_app app_data_file:dir { getattr search };
 
-# Acccess to its own service and broadcasts
-allow qcrilam_app activity_service:service_manager find;
+# Access services that should be available to all apps
+allow qcrilam_app app_api_service:service_manager find;
+
 # Find media.audio_flinger
 allow qcrilam_app audioserver_service:service_manager find;
 # Find isub


### PR DESCRIPTION
app_api_service is now broadly in Android R to encapsulate all normal
system services an app should have access to. Issues were initially
noticed when these two apps repeatedly spew the following denials every
half second:

    denied  { find } for name=tethering scontext=u:r:modemconfig_app:s0 tcontext=u:object_r:tethering_service:s0 tclass=service_manager
    denied  { find } for name=tethering scontext=u:r:qcrilam_app:s0 tcontext=u:object_r:tethering_service:s0 tclass=service_manager

It is clear that all other app types (priv_app and such) have access to
these services through app_api_service; grant our apps access to it too.
