### PR TITLE
[SEPOLICY] [Q/R] hal_audio_default: Allow reading thermal status

### DIFF
--- a/vendor/hal_audio_default.te
+++ b/vendor/hal_audio_default.te
@@ -15,4 +15,6 @@ allow hal_audio_default powerhal_socket:dir { open read search };
 allow hal_audio_default audio_vendor_data_file:dir rw_dir_perms;
 allow hal_audio_default audio_vendor_data_file:file create_file_perms;
 
+r_dir_file(hal_audio_default, sysfs)
 r_dir_file(hal_audio_default, sysfs_soc)
+r_dir_file(hal_audio_default, sysfs_thermal)


### PR DESCRIPTION
Allow the Audio HAL to read thermal information. Solves:

    denied { search } for name="thermal" dev="sysfs" scontext=u:r:hal_audio_default:s0 tcontext=u:object_r:sysfs_thermal:s0 tclass=dir
    denied { read } for name="thermal" dev="sysfs" scontext=u:r:hal_audio_default:s0 tcontext=u:object_r:sysfs_thermal:s0 tclass=dir
    denied { read } for name="class" dev="sysfs" scontext=u:r:hal_audio_default:s0 tcontext=u:object_r:sysfs:s0 tclass=dir
    msm8974_platform: Unable to open /sys/class/thermal
