### PR TITLE
[SEPOLICY] [Q/R] hal_miscta_default: Add to hal_allocator client domain

### DIFF
--- a/vendor/hal_miscta_default.te
+++ b/vendor/hal_miscta_default.te
@@ -6,7 +6,7 @@ init_daemon_domain(hal_miscta_default)
 hwbinder_use(hal_miscta_default)
 add_hwservice(hal_miscta_default, vnd_somc_miscta_hwservice)
 
-allow hal_miscta_default hidl_memory_hwservice:hwservice_manager find;
+hal_client_domain(hal_miscta_default, hal_allocator)
 
 get_prop(hal_miscta_default, hwservicemanager_prop)
 


### PR DESCRIPTION
On Android R restrictions on fd sharing seem to be more strict,
resulting in the following error observed on Seine:

    E vendor.somc.hardware.miscta@1.0-service: MisctaGlobal::misctaReadUnit: hidl memory mapping failed!
    E audio_hw_sony_cirrus_playback: get_ta_array: Cannot read TA unit 4702 of size 4: error 1
    I audio_hw_sony_cirrus_playback: get_ta_array: Read TA unit 4702 (size=4) values: 0x0 0x0 0x0 0x0
    D msm8974_platform: platform_get_snd_device_backend_interface: hw_interface set for device HDMI
    W avc: denied { use } for path="/dev/ashmeme729d33a-ee97-4fa2-b8c3-f6200874e6ef" scontext=u:r:hal_miscta_default:s0 tcontext=u:r:hal_allocator_default:s0 tclass=fd

Instead of granting this permission directly or through the missing
binder_call macro, make hal_miscta_default part of the hal_allocator
client domain to implicitly grant all rights as necessary.
