### PR TITLE
[SEPOLICY] [Q/R] Init relabelto for more block devices, remove gpt_block_device

### DIFF
--- a/vendor/device.te
+++ b/vendor/device.te
@@ -24,7 +24,6 @@ type fingerprint_device, dev_type;
 type ab_block_device, dev_type;
 type xbl_block_device, dev_type;
 type wlan_device, dev_type;
-type gpt_block_device, dev_type;
 type dtbo_block_device, dev_type;
 type vbmeta_block_device, dev_type;
 type hvdcp_opti_device, dev_type;

--- a/vendor/hal_bootctl_default.te
+++ b/vendor/hal_bootctl_default.te
@@ -7,7 +7,6 @@ allow hal_bootctl_default block_device:dir r_dir_perms;
 
 # Edit the attributes stored in the GPT.
 allow hal_bootctl_default block_device:blk_file getattr;
-allow hal_bootctl_default gpt_block_device:blk_file rw_file_perms;
 allow hal_bootctl_default boot_block_device:blk_file rw_file_perms;
 allow hal_bootctl_default misc_block_device:blk_file rw_file_perms;
 allow hal_bootctl_default root_block_device:blk_file rw_file_perms;

--- a/vendor/init.te
+++ b/vendor/init.te
@@ -5,6 +5,13 @@ allow init {tmpfs configfs }:lnk_file create_file_perms;
 allow init { mnt_vendor_file vendor_firmware_file adsprpcd_file }:dir mounton;
 allow init vendor_firmware_file:filesystem { mount relabelfrom };
 
+# AOSP init only covers system_block_device, add our own:
+allow init {
+    boot_block_device
+    dtbo_block_device
+    vbmeta_block_device
+}:{ blk_file lnk_file } relabelto;
+
 dontaudit init kernel:system module_request;
 
 # Ignore all accidental O_CREAT open() calls on unsupported filesystems:


### PR DESCRIPTION
Allow init to relabel "custom" block devices, and remove `gpt_block_device` which serves the same purpose as `root_block_device` from AOSP.
