### PR TITLE
[SEPOLICY] [R] Add labels for new mdm_helper and ATFWD-daemon

### DIFF
--- a/vendor/atfwd_daemon.te
+++ b/vendor/atfwd_daemon.te
@@ -1,0 +1,4 @@
+type atfwd_daemon, domain;
+type atfwd_daemon_exec, exec_type, vendor_file_type, file_type;
+
+init_daemon_domain(atfwd_daemon)

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -56,6 +56,7 @@
 /odm/bin/hw/vendor\.somc\.hardware\.modemswitcher@1\.0-service    u:object_r:hal_modemsw_default_exec:s0
 /odm/bin/hw/vendor\.somc\.hardware\.miscta@1\.0-service           u:object_r:hal_miscta_default_exec:s0
 /odm/bin/hw/android\.hardware\.keymaster@4\.0-service-qti         u:object_r:hal_keymaster_default_exec:s0
+/odm/bin/ATFWD-daemon                           u:object_r:atfwd_daemon_exec:s0
 /odm/bin/adpl                                   u:object_r:adpl_exec:s0
 /odm/bin/adsprpcd                               u:object_r:adsprpcd_exec:s0
 /odm/bin/cdsprpcd                               u:object_r:cdsprpcd_exec:s0

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -68,6 +68,7 @@
 /odm/bin/imsqmidaemon                           u:object_r:ims_exec:s0
 /odm/bin/imsrcsd                                u:object_r:ims_exec:s0
 /odm/bin/irsc_util                              u:object_r:irsc_util_exec:s0
+/odm/bin/mdm_helper                             u:object_r:mdm_helper_exec:s0
 /odm/bin/mlog_qmi_service                       u:object_r:mlog_qmi_exec:s0
 /odm/bin/msm_irqbalance                         u:object_r:msm_irqbalance_exec:s0
 /odm/bin/netmgrd                                u:object_r:netmgrd_exec:s0

--- a/vendor/mdm_helper.te
+++ b/vendor/mdm_helper.te
@@ -1,0 +1,4 @@
+type mdm_helper, domain;
+type mdm_helper_exec, exec_type, vendor_file_type, file_type;
+
+init_daemon_domain(mdm_helper)


### PR DESCRIPTION
These are just the labels so that the binaries are properly labeled next time `/odm` is built; actual policy comes later.

See also https://github.com/sonyxperiadev/device-sony-common/pull/811
