### PR TITLE
[SEPOLICY] [R] file_contexts: Label QTI display.composer-service

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -115,6 +115,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.usb@1\.0-service\.basic                    u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.allocator-service             u:object_r:hal_graphics_allocator_default_exec:s0
+/(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.composer-service              u:object_r:hal_graphics_composer_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.vibrator@1\.2-service                  u:object_r:hal_vibrator_default_exec:s0
 
 # sysfs paths


### PR DESCRIPTION
LA.UM.9.xx display HALs now provide a composer executable directly instead of going through `android.hardware.graphics.composer@x.y-service` and a libhardware module.

