### PR TITLE
[sepolicy] [R] Initial (graphics) labels and rules for edo support

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -147,7 +147,7 @@
 #
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.msm89(52|96|98)\.so  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sdm(660|845)\.so     u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sm(8150|6125)\.so    u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sm(8[12]50|6125)\.so u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqdMetaData(\.legacy)?\.so     u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqservice\.so                  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqdutils\.so                   u:object_r:same_process_hal_file:s0
@@ -156,7 +156,7 @@
 
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.msm89(52|96|98)\.so   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sdm(660|845)\.so      u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sm(8150|6125)\.so     u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sm(8[12]50|6125)\.so  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.qcom\.so              u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libEGL_adreno\.so         u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libGLESv1_CM_adreno\.so   u:object_r:same_process_hal_file:s0
@@ -208,9 +208,12 @@
 /(system/vendor|vendor)/lib(64)?/camera\.device@3\.4-external-impl\.so                  u:object_r:same_process_hal_file:s0
 
 # Graphics mapper
-/(system/vendor|vendor)/lib(64)?/hw/android\.hardware\.graphics\.mapper@3\.0-impl-qti-display\.so       u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapper@[0-9]+\.[0-9]+\.so              u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapperextensions@1\.[0-9]+\.so         u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/hw/android\.hardware\.graphics\.mapper@[0-9]+\.[0-9]+-impl-qti-display\.so     u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapper@[0-9]+\.[0-9]+\.so                      u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapperextensions@[0-9]+\.[0-9]+\.so            u:object_r:same_process_hal_file:s0
+
+# Loaded into SurfaceFlinger
+/(system/vendor|vendor|odm)/lib(64)?/libgralloc\.qti\.so            u:object_r:same_process_hal_file:s0
 
 # data files
 /data/vendor/audio(/.*)?               u:object_r:audio_vendor_data_file:s0

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -6,7 +6,7 @@ vndbinder_use(hal_graphics_composer_default)
 
 # HWC hosts the qdisplay and display config services:
 add_service(hal_graphics_composer_default, qdisplay_service)
-add_hwservice(hal_graphics_composer_default, hal_display_config_hwservice)
+hal_attribute_hwservice(hal_graphics_composer, hal_display_config_hwservice)
 
 allow hal_graphics_composer_default { graphics_device video_device }:chr_file rw_file_perms;
 rw_diag_device(hal_graphics_composer_default)

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -22,8 +22,9 @@ vendor.qti.hardware.data.iwlan::IIWlan                                  u:object
 vendor.qti.hardware.data.latency::ILinkLatency                          u:object_r:vnd_data_linklatency_hwservice:s0
 vendor.qti.hardware.slmadapter::ISlmAdapter                             u:object_r:vnd_data_slmadapter_hwservice:s0
 # QTI HAL interfaces for display services:
-vendor.qti.hardware.display.mapper::IQtiMapper                          u:object_r:hal_graphics_mapper_hwservice:s0
 vendor.qti.hardware.display.allocator::IQtiAllocator                    u:object_r:hal_graphics_allocator_hwservice:s0
+vendor.qti.hardware.display.composer::IQtiComposer                      u:object_r:hal_graphics_composer_hwservice:s0
+vendor.qti.hardware.display.mapper::IQtiMapper                          u:object_r:hal_graphics_mapper_hwservice:s0
 # QTI DPM:
 com.qualcomm.qti.dpm.api::IdpmQmi                                       u:object_r:vnd_qti_dpm_hwservice:s0
 # SoMC modem switcher:

--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -4,6 +4,8 @@ type sscrpcd_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(sscrpcd)
 
+wakelock_use(sscrpcd)
+
 allow sscrpcd self:capability net_bind_service;
 
 allow sscrpcd self:qipcrtr_socket create_socket_perms_no_ioctl;


### PR DESCRIPTION
This is an initial set of rules to accept the new 9.12 graphics stack with different binaries and more HIDL/HAL revisions. One other patch for wakelocks in sscrpcd, all the new binaries (atfwd, mdm etc) will be done at a later date. This at least allows edo to boot in enforcing.
