### PR TITLE
[DONOTMERGE] [sepolicy] [R] Rework camera policy

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -147,7 +147,7 @@
 #
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.msm89(52|96|98)\.so  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sdm(660|845)\.so     u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sm(8150|6125)\.so    u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/hw/gralloc\.sm(8[12]50|6125)\.so u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqdMetaData(\.legacy)?\.so     u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqservice\.so                  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/libqdutils\.so                   u:object_r:same_process_hal_file:s0
@@ -156,7 +156,7 @@
 
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.msm89(52|96|98)\.so   u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sdm(660|845)\.so      u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sm(8150|6125)\.so     u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.sm(8[12]50|6125)\.so  u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/hw/vulkan\.qcom\.so              u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libEGL_adreno\.so         u:object_r:same_process_hal_file:s0
 /(system/vendor|vendor|odm)/lib(64)?/(egl/)?libGLESv1_CM_adreno\.so   u:object_r:same_process_hal_file:s0
@@ -208,9 +208,12 @@
 /(system/vendor|vendor)/lib(64)?/camera\.device@3\.4-external-impl\.so                  u:object_r:same_process_hal_file:s0
 
 # Graphics mapper
-/(system/vendor|vendor)/lib(64)?/hw/android\.hardware\.graphics\.mapper@3\.0-impl-qti-display\.so       u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapper@[0-9]+\.[0-9]+\.so              u:object_r:same_process_hal_file:s0
-/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapperextensions@1\.[0-9]+\.so         u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/hw/android\.hardware\.graphics\.mapper@[0-9]+\.[0-9]+-impl-qti-display\.so     u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapper@[0-9]+\.[0-9]+\.so                      u:object_r:same_process_hal_file:s0
+/(system/vendor|vendor)/lib(64)?/vendor\.qti\.hardware\.display\.mapperextensions@[0-9]+\.[0-9]+\.so            u:object_r:same_process_hal_file:s0
+
+# Loaded into SurfaceFlinger
+/(system/vendor|vendor|odm)/lib(64)?/libgralloc\.qti\.so            u:object_r:same_process_hal_file:s0
 
 # data files
 /data/vendor/audio(/.*)?               u:object_r:audio_vendor_data_file:s0

--- a/vendor/hal_camera_default.te
+++ b/vendor/hal_camera_default.te
@@ -5,15 +5,7 @@ qrtr_socket_create(hal_camera_default)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final
 allowxperm hal_camera self:socket ioctl { IPC_ROUTER_IOCTL_LOOKUP_SERVER IPC_ROUTER_IOCTL_BIND_CONTROL_PORT };
 
-allow hal_camera_default {
-     fwk_display_hwservice
-     hal_graphics_mapper_hwservice
-}:hwservice_manager find;
-
-binder_call(hal_camera_default, hal_graphics_composer)
-binder_call(hal_camera_default, system_server)
-binder_call(hal_camera_default, hal_graphics_allocator)
-binder_call(hal_camera_default, surfaceflinger)
+hal_client_domain(hal_camera_default, hal_graphics_allocator)
 
 set_prop(hal_camera_default, camera_prop)
 set_prop(hal_camera_default, vendor_camera_prop)

--- a/vendor/hal_camera_default.te
+++ b/vendor/hal_camera_default.te
@@ -6,6 +6,7 @@ qrtr_socket_create(hal_camera_default)
 allowxperm hal_camera self:socket ioctl { IPC_ROUTER_IOCTL_LOOKUP_SERVER IPC_ROUTER_IOCTL_BIND_CONTROL_PORT };
 
 hal_client_domain(hal_camera_default, hal_graphics_allocator)
+hal_client_domain(hal_camera_default, hal_graphics_composer)
 
 set_prop(hal_camera_default, camera_prop)
 set_prop(hal_camera_default, vendor_camera_prop)

--- a/vendor/hal_camera_default.te
+++ b/vendor/hal_camera_default.te
@@ -18,22 +18,18 @@ binder_call(hal_camera_default, surfaceflinger)
 set_prop(hal_camera_default, camera_prop)
 set_prop(hal_camera_default, vendor_camera_prop)
 
-allow hal_camera_default sysfs_camera:dir r_dir_perms;
-allow hal_camera_default sysfs_camera:file r_file_perms;
+r_dir_file(hal_camera_default, sysfs_camera)
 
 allow hal_camera_default gpu_device:chr_file rw_file_perms;
 allow hal_camera_default qdsp_device:chr_file r_file_perms;
 
-allow hal_camera_default hal_power_default:unix_stream_socket connectto;
+unix_socket_connect(hal_camera_default, powerhal, hal_power_default)
 allow hal_camera_default powerhal_socket:dir search;
-allow hal_camera_default powerhal_socket:sock_file write;
 
 unix_socket_connect(hal_camera_default, cashsvr, cashsvr)
 allow hal_camera_default cashsvr_socket:dir search;
-allow hal_camera_default cashsvr_socket:sock_file write;
 
-allow hal_camera_default sysfs_msm_subsys:dir r_dir_perms;
-allow hal_camera_default sysfs_msm_subsys:file r_file_perms;
+r_dir_file(hal_camera_default, sysfs_msm_subsys)
 r_dir_file(hal_camera_default, sysfs_soc)
 r_dir_file(hal_camera_default, sysfs_esoc)
 

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -6,7 +6,7 @@ vndbinder_use(hal_graphics_composer_default)
 
 # HWC hosts the qdisplay and display config services:
 add_service(hal_graphics_composer_default, qdisplay_service)
-add_hwservice(hal_graphics_composer_default, hal_display_config_hwservice)
+hal_attribute_hwservice(hal_graphics_composer, hal_display_config_hwservice)
 
 allow hal_graphics_composer_default { graphics_device video_device }:chr_file rw_file_perms;
 rw_diag_device(hal_graphics_composer_default)

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -22,8 +22,9 @@ vendor.qti.hardware.data.iwlan::IIWlan                                  u:object
 vendor.qti.hardware.data.latency::ILinkLatency                          u:object_r:vnd_data_linklatency_hwservice:s0
 vendor.qti.hardware.slmadapter::ISlmAdapter                             u:object_r:vnd_data_slmadapter_hwservice:s0
 # QTI HAL interfaces for display services:
-vendor.qti.hardware.display.mapper::IQtiMapper                          u:object_r:hal_graphics_mapper_hwservice:s0
 vendor.qti.hardware.display.allocator::IQtiAllocator                    u:object_r:hal_graphics_allocator_hwservice:s0
+vendor.qti.hardware.display.composer::IQtiComposer                      u:object_r:hal_graphics_composer_hwservice:s0
+vendor.qti.hardware.display.mapper::IQtiMapper                          u:object_r:hal_graphics_mapper_hwservice:s0
 # QTI DPM:
 com.qualcomm.qti.dpm.api::IdpmQmi                                       u:object_r:vnd_qti_dpm_hwservice:s0
 # SoMC modem switcher:

--- a/vendor/sscrpcd.te
+++ b/vendor/sscrpcd.te
@@ -4,6 +4,8 @@ type sscrpcd_exec, exec_type, vendor_file_type, file_type;
 
 init_daemon_domain(sscrpcd)
 
+wakelock_use(sscrpcd)
+
 allow sscrpcd self:capability net_bind_service;
 
 allow sscrpcd self:qipcrtr_socket create_socket_perms_no_ioctl;


### PR DESCRIPTION
Clean up the camera policy by using client/server domains instead of manual service and binder rules.

### TODO:
- Finalize for edo;
- Test on !CamX (this works on Griffin with OpenCamera);
- Check again if we really need access to `system_server` and `surfaceflinger` (and/or any of the services hosted by those domains).
