### PR TITLE
[sepolicy] [Q/R] hal_graphics_composer_default: Grant write access to "leds"

### DIFF
--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -15,7 +15,7 @@ allow hal_graphics_composer_default oemfs:dir search;
 allow hal_graphics_composer_default persist_display_file:dir getattr;
 allow hal_graphics_composer_default persist_file:dir search;
 
-r_dir_file(hal_graphics_composer_default, sysfs_leds)
+r_dir_rw_file(hal_graphics_composer_default, sysfs_leds)
 r_dir_file(hal_graphics_composer_default, sysfs_camera)
 r_dir_file(hal_graphics_composer_default, sysfs_msm_subsys)
 allow hal_graphics_composer_default sysfs_mdss_mdp_caps:file r_file_perms;


### PR DESCRIPTION
Newer display composers (like those on 8.1 and 9.12 tags) support setting brightness directly instead of going through the lights HAL. On 8.1 this was so horribly broken that we ended up disabling it [1], but on 9.12 it is implicitly working just fine. For this the HAL now requires write access to led files.

Note that it might be saner to define a new `sysfs_backlight` for this; leds seem to be a remnant from ancient kernels having the backlight under `class/leds`, but alas - that requires updating _all_ platforms.

[1]: https://github.com/sonyxperiadev/hardware-qcom-display/pull/32

---

@jerpelea please do the usual rebase after merging this :grimacing:
