### PR TITLE
[sepolicy] [R/master] file_contexts: Label all gnss service binary revisions

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -112,8 +112,7 @@
 /(system/vendor|vendor)/bin/timekeep                                                         u:object_r:timekeep_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.biometrics\.fingerprint@2\.1-service\.sony u:object_r:hal_fingerprint_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.bluetooth@1\.0-service-qti                 u:object_r:hal_bluetooth_default_exec:s0
-/(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@1\.1-service-qti                      u:object_r:hal_gnss_qti_exec:s0
-/(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@2\.0-service-qti                      u:object_r:hal_gnss_qti_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@[0-9]+\.[0-9]+-service-qti            u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.3-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health@2\.0-service\.sony                  u:object_r:hal_health_default_exec:s0


### PR DESCRIPTION
We are upgrading to a new version again (2.1 this time), and repeatedly bumping these in policy is tedious. We should probably give the entire set of labels a good scrutineering and replace all numbers with `[0-9]+` to match the nature of constantly changing revisions.
