### PR TITLE
[R] Split qtidataservices_app from platform_app

### DIFF
--- a/vendor/qtidataservices_app.te
+++ b/vendor/qtidataservices_app.te
@@ -1,0 +1,10 @@
+type qtidataservices_app, domain;
+
+app_domain(qtidataservices_app)
+
+# Find the vendor.qti.hardware.data.iwlan::IIWlan HIDL service
+# And grant binder access to the host (`rild`, `cnd`)
+hal_client_domain(qtidataservices_app, hal_telephony)
+
+# Access services that should be available to all apps
+allow qtidataservices_app app_api_service:service_manager find;

--- a/vendor/seapp_contexts
+++ b/vendor/seapp_contexts
@@ -1,4 +1,5 @@
 user=system seinfo=platform name=com.sony.timekeep domain=timekeep_app type=app_data_file
+user=_app seinfo=platform name=.qtidataservices domain=qtidataservices_app type=app_data_file levelFrom=all
 user=_app seinfo=platform name=com.sony.qcrilam domain=qcrilam_app type=app_data_file
 user=_app seinfo=platform name=com.sony.opentelephony.modemconfig isPrivApp=true domain=modemconfig_app type=app_data_file
 # Why app_data_file and not system_app_data_file?


### PR DESCRIPTION
Without this commit I had no service with enforcing before, for some reason.

Turning airplane mode on/off would also spam the denial.

Simply doing
```
allow platform_app vnd_data_iwlan_hwservice:hwservice_manager { find };
```
would yield a neverallow.

Tested on kumano/bahamut.
