### PR TITLE
[master] Add support for QTI USB HAL

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -124,7 +124,6 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.3-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health@2\.0-service\.sony                  u:object_r:hal_health_default_exec:s0
-/(system/vendor|vendor)/bin/hw/android\.hardware\.usb@1\.0-service\.basic                    u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.allocator-service             u:object_r:hal_graphics_allocator_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.composer-service              u:object_r:hal_graphics_composer_default_exec:s0

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -125,6 +125,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.3-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health@2\.0-service\.sony                  u:object_r:hal_health_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.usb\@1\.[0-2]-service-qti                  u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.allocator-service             u:object_r:hal_graphics_allocator_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.composer-service              u:object_r:hal_graphics_composer_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.vibrator@1\.2-service                  u:object_r:hal_vibrator_default_exec:s0


### PR DESCRIPTION
Add android.hardware.usb@1.2-service-qti HAL for devices
running on 4.19 kernel.

This version of the USB HAL is not intended to be used
on targets with kernels older than 4.19 (since it relies on
Type-C Class to be enabled).