### PR TITLE
[S] sepolicy.mk: Follow rename change from upstream

### DIFF
--- a/sepolicy.mk
+++ b/sepolicy.mk
@@ -5,13 +5,8 @@ LOCAL_SEPOLICY := device/sony/sepolicy
 BOARD_VENDOR_SEPOLICY_DIRS += \
     $(LOCAL_SEPOLICY)/vendor
 
-# TODO(b/systemext-policy): Will be renamed to:
-# - SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS
-# - SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS
-# once Android S lands and throw a warning/error
-# See https://r.android.com/q/topic:board-system-ext-sepolicy
-BOARD_PLAT_PRIVATE_SEPOLICY_DIR += \
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     $(LOCAL_SEPOLICY)/system_ext/private
 
-BOARD_PLAT_PUBLIC_SEPOLICY_DIR += \
+SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS += \
     $(LOCAL_SEPOLICY)/system_ext/public


### PR DESCRIPTION
In Android S (12) the BOARD_PLAT_`*`_SEPOLICY_DIR variables
have been renamed to SYSTEM_EXT_`*`_SEPOLICY_DIRS.

See for reference: https://android-review.googlesource.com/q/topic:board-system-ext-sepolicy