### PR TITLE
[R/S] mdm_helper: Allow executing "kickstart" and grant read-access to efs sync partitions

### DIFF
--- a/vendor/device.te
+++ b/vendor/device.te
@@ -2,6 +2,7 @@ type avtimer_device, dev_type;
 type bt_device, dev_type;
 type diag_device, dev_type, mlstrustedobject;
 type dpl_ctl_device, dev_type;
+type efs_boot_device, dev_type;
 type esoc_device, dev_type;
 type ipa_dev, dev_type;
 type ipa_odl_ctl_device, dev_type;

--- a/vendor/mdm_helper.te
+++ b/vendor/mdm_helper.te
@@ -5,6 +5,9 @@ init_daemon_domain(mdm_helper)
 
 wakelock_use(mdm_helper)
 
+# Allow mdm_helper to execute /vendor/bin/ks
+allow mdm_helper ks_exec:file execute_no_trans;
+
 allow mdm_helper esoc_device:chr_file r_file_perms;
 
 r_dir_file(mdm_helper, sysfs_esoc)

--- a/vendor/mdm_helper.te
+++ b/vendor/mdm_helper.te
@@ -15,3 +15,7 @@ r_dir_file(mdm_helper, sysfs_msm_subsys)
 
 # Needed to allow boot over PCIe
 allow mdm_helper mhi_device:chr_file rw_file_perms;
+
+#Needed by ks in order to access the efs sync partitions
+allow mdm_helper block_device:dir r_dir_perms;
+allow mdm_helper efs_boot_device:blk_file r_file_perms;


### PR DESCRIPTION
These two patches should address all the remaining sepolicy warnings around `mdm_helper`.