### PR TITLE
treewide: remove debugfs entries

### DIFF
--- a/vendor/genfs_contexts
+++ b/vendor/genfs_contexts
@@ -69,15 +69,12 @@ genfscon sysfs /power/system_sleep/stats                                u:object
 
 genfscon debugfs /kgsl/proc                           u:object_r:debugfs_kgsl:s0
 genfscon debugfs /clk/debug_suspend                   u:object_r:debugfs_clk:s0
-genfscon debugfs /wlan                                u:object_r:debugfs_wlan:s0
-genfscon debugfs /wlan0                               u:object_r:debugfs_wlan:s0
 
 genfscon debugfs /rpm_stats                           u:object_r:debugfs_rpm:s0
 genfscon debugfs /rpm_master_stats                    u:object_r:debugfs_rpm:s0
 genfscon debugfs /ion                                 u:object_r:debugfs_ion:s0
 genfscon debugfs /system_stats                        u:object_r:debugfs_rpm:s0
 genfscon debugfs /msm_ipc_router                      u:object_r:debugfs_ipc:s0
-genfscon debugfs /ipc_logging                         u:object_r:debugfs_ipc_logging:s0
 genfscon debugfs /mdp                                 u:object_r:debugfs_mdp:s0
 genfscon debugfs /rmt_storage                         u:object_r:debugfs_rmt_storage:s0
 genfscon debugfs /icnss                               u:object_r:debugfs_icnss:s0

--- a/vendor/hal_bluetooth_default.te
+++ b/vendor/hal_bluetooth_default.te
@@ -14,7 +14,6 @@ set_prop(hal_bluetooth_default, wc_prop)
 set_prop(hal_bluetooth_default, bluetooth_prop)
 set_prop(hal_bluetooth_default, vendor_bluetooth_prop)
 
-r_dir_file(hal_bluetooth_default, debugfs_ipc_logging)
 r_dir_file(hal_bluetooth_default, persist_file)
 r_dir_file(hal_bluetooth_default, persist_bluetooth_file)
 r_dir_file(hal_bluetooth_default, vendor_firmware_file)

--- a/vendor/hal_memtrack_default.te
+++ b/vendor/hal_memtrack_default.te
@@ -1,2 +1,1 @@
-allow hal_memtrack_default debugfs_kgsl:file { open read getattr };
 allow hal_memtrack_default sysfs:file { getattr open read };

--- a/vendor/hal_power_default.te
+++ b/vendor/hal_power_default.te
@@ -7,8 +7,6 @@ allow hal_power_default sysfs_devices_system_cpu:file w_file_perms;
 get_prop(hal_power_default, vendor_powerhal_prop)
 
 # Read sysfs stats files:
-r_dir_file(hal_power_default, debugfs_wlan)
-allow hal_power_default debugfs_rpm:file r_file_perms;
 allow hal_power_default sysfs_system_sleep_stats:file r_file_perms;
 allow hal_power_default sysfs_rpm:file r_file_perms;
 allow hal_power_default sysfs_wlan_power_stats:file r_file_perms;

--- a/vendor/hal_wifi_default.te
+++ b/vendor/hal_wifi_default.te
@@ -1,8 +1,6 @@
 # /sys/kernel/boot_wlan/boot_wlan
 allow hal_wifi_default sysfs_boot_wlan:file w_file_perms;
 
-r_dir_file(hal_wifi_default, debugfs_wlan)
-
 allow hal_wifi_default kernel:system module_request;
 allow hal_wifi_default tombstone_wifi_data_file:dir rw_dir_perms;
 

--- a/vendor/kernel.te
+++ b/vendor/kernel.te
@@ -1,12 +1,7 @@
 userdebug_or_eng(`
   # for diag over socket
   allow kernel self:socket create;
-  # A kernel worker has to read from /d/wlan{,0}/,
-  # otherwise debug files are not created there.
-  r_dir_file(kernel, debugfs_wlan)
 ')
-
-r_dir_file(kernel, debugfs_ipc_logging)
 
 allow kernel self:qipcrtr_socket create_socket_perms_no_ioctl;
 
@@ -14,5 +9,3 @@ allow kernel self:qipcrtr_socket create_socket_perms_no_ioctl;
 dontaudit kernel self:socket create;
 
 dontaudit kernel kernel:system module_request;
-dontaudit kernel debugfs_wlan:dir r_dir_perms;
-dontaudit kernel debugfs_wlan:file r_file_perms;

--- a/vendor/per_mgr.te
+++ b/vendor/per_mgr.te
@@ -23,7 +23,6 @@ allowxperm per_mgr self:socket ioctl msm_sock_ipc_ioctls;
 allow per_mgr ssr_device:chr_file { open read };
 allow per_mgr device:dir search;
 
-r_dir_file(per_mgr, debugfs_ipc_logging)
 r_dir_file(per_mgr, sysfs_msm_subsys)
 r_dir_file(per_mgr, sysfs_esoc)
 

--- a/vendor/rmt_storage.te
+++ b/vendor/rmt_storage.te
@@ -29,7 +29,6 @@ allow rmt_storage sysfs_rmtfs:dir search;
 allow rmt_storage sysfs_rmtfs:file r_file_perms;
 
 allow rmt_storage debugfs_rmt_storage:dir search;
-allow rmt_storage debugfs_rmt_storage:file w_file_perms;
 
 qrtr_socket_create(rmt_storage)
 # TODO (b/deprecate-old-ipc-router): Remove 4.9 ipc-router compatibility `socket' when kernel 4.14 is final


### PR DESCRIPTION
debugfs is not cool anymore, aosp says it's a strict neverallow :(