### PR TITLE
[t-mr1] vendor: Define new policy rule to read gpu model

### DIFF
--- a/vendor/bootanim.te
+++ b/vendor/bootanim.te
@@ -1,0 +1,2 @@
+# allow bootanim to read kgsl gpu model
+allow bootanim sysfs_kgsl_gpu_model:file r_file_perms;

--- a/vendor/file.te
+++ b/vendor/file.te
@@ -26,6 +26,7 @@ type sysfs_system_sleep_stats, sysfs_type, fs_type;
 type sysfs_timestamp_switch, sysfs_type, fs_type;
 type sysfs_tof_sensor, fs_type, sysfs_type;
 type sysfs_wlan_power_stats, fs_type, sysfs_type;
+type sysfs_kgsl_gpu_model, sysfs_type, fs_type;
 
 type debugfs_clk, debugfs_type, fs_type;
 type debugfs_icnss, debugfs_type, fs_type;

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -164,6 +164,8 @@
 # Clearpad: /sys/devices/virtual/input/clearpad/glove:
 /sys/devices/virtual/input/input[0-9]+/glove                                                 u:object_r:sysfs_glove_mode:s0
 /sys/devices/virtual/input/lge_touch/glove_mode                                              u:object_r:sysfs_glove_mode:s0
+# KGSL
+/sys/devices/platform/soc/[a-f0-9]+.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpu_model                    u:object_r:sysfs_kgsl_gpu_model:s0
 
 ###############################################
 # same-process HAL files and their dependencies

--- a/vendor/hal_graphics_allocator_default.te
+++ b/vendor/hal_graphics_allocator_default.te
@@ -1,3 +1,6 @@
 r_dir_file(hal_graphics_allocator_default, sysfs_graphics)
 r_dir_file(hal_graphics_allocator_default, sysfs_mdss_mdp_caps)
 r_dir_file(hal_graphics_allocator_default, sysfs_msm_subsys)
+
+# allow hal_graphics_allocator_default to read kgsl gpu model
+allow hal_graphics_allocator_default sysfs_kgsl_gpu_model:file r_file_perms;

--- a/vendor/hal_graphics_composer_default.te
+++ b/vendor/hal_graphics_composer_default.te
@@ -29,3 +29,6 @@ create_dir_file(hal_graphics_composer_default, display_vendor_data_file)
 
 # HWC_UeventThread
 allow hal_graphics_composer_default self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;
+
+# allow hal_graphics_composer_default to read kgsl gpu model
+allow hal_graphics_composer_default sysfs_kgsl_gpu_model:file r_file_perms;

--- a/vendor/platform_app.te
+++ b/vendor/platform_app.te
@@ -1,1 +1,4 @@
 allow platform_app nfc_service:service_manager find;
+
+# allow platform_app to read kgsl gpu model
+allow platform_app sysfs_kgsl_gpu_model:file r_file_perms;

--- a/vendor/priv_app.te
+++ b/vendor/priv_app.te
@@ -1,3 +1,6 @@
 allow priv_app sysfs_android_usb:file r_file_perms;
 
 allow priv_app sysfs_mac_address:file r_file_perms;
+
+# allow priv_app to read kgsl gpu model
+allow priv_app sysfs_kgsl_gpu_model:file r_file_perms;

--- a/vendor/surfaceflinger.te
+++ b/vendor/surfaceflinger.te
@@ -3,6 +3,9 @@ dontaudit surfaceflinger kernel:system module_request;
 
 allow surfaceflinger debugfs_ion:dir search;
 
+# allow surfaceflinger to read kgsl gpu model
+allow surfaceflinger sysfs_kgsl_gpu_model:file r_file_perms;
+
 r_dir_rw_file(surfaceflinger, sysfs_graphics)
 
 binder_call(surfaceflinger, hal_camera_default)

--- a/vendor/system_app.te
+++ b/vendor/system_app.te
@@ -17,3 +17,6 @@ allow system_app fs_bpf:dir search;
 allow system_app proc_pagetypeinfo:file r_file_perms;
 allow system_app sysfs_zram:dir search;
 allow system_app sysfs_zram:file r_file_perms;
+
+# allow system_app to read kgsl gpu model
+allow system_app sysfs_kgsl_gpu_model:file r_file_perms;

--- a/vendor/system_server.te
+++ b/vendor/system_server.te
@@ -24,4 +24,7 @@ rw_dir_file(system_server, qmuxd_socket)
 allow system_server sysfs_rtc:dir r_dir_perms;
 allow system_server sysfs_rtc:{ file lnk_file } r_file_perms;
 
+# allow system_server to read kgsl gpu model
+allow system_server sysfs_kgsl_gpu_model:file r_file_perms;
+
 dontaudit system_server vfat:dir r_dir_perms;


### PR DESCRIPTION
Add  a new file context label for gpu_model sysfs entry. allowed read access to that entry.

Addressing the following denials:
type=1400 audit(0.0:4726): avc: denied { read } for name="gpu_model" dev="sysfs" ino=58119 scontext=u:r:system_server:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
type=1400 audit(0.0:32):   avc: denied { read } for name="gpu_model" dev="sysfs" ino=59584 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:sysfs_kgsl_gpu_model:s0 tclass=file permissive=1
type=1400 audit(0.0:48):   avc: denied { read } for name="gpu_model" dev="sysfs" ino=59584 scontext=u:r:hal_graphics_allocator_default:s0 tcontext=u:object_r:sysfs_kgsl_gpu_model:s0 tclass=file permissive=1
type=1400 audit(0.0:45):   avc: denied { read } for name="gpu_model" dev="sysfs" ino=59584 scontext=u:r:surfaceflinger:s0 tcontext=u:object_r:sysfs_kgsl_gpu_model:s0 tclass=file permissive=1
type=1400 audit(0.0:59):   avc: denied { read } for name="gpu_model" dev="sysfs" ino=59584 scontext=u:r:bootanim:s0 tcontext=u:object_r:sysfs_kgsl_gpu_model:s0 tclass=file permissive=1
type=1400 audit(0.0:6514): avc: denied { read } for name="gpu_model" dev="sysfs" ino=59584 scontext=u:r:system_app:s0 tcontext=u:object_r:sysfs_kgsl_gpu_model:s0 tclass=file permissive=1
type=1400 audit(0.0:6539): avc: denied { read } for name="gpu_model" dev="sysfs" ino=59584 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs_kgsl_gpu_model:s0 tclass=file permissive=1 app=com.android.launcher3
type=1400 audit(0.0:6528): avc: denied { read } for name="gpu_model" dev="sysfs" ino=59584 scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:sysfs_kgsl_gpu_model:s0 tclass=file permissive=1 app=com.android.systemui