### PR TITLE
Drop `bt_device` type that is defined in AOSP 14

### DIFF
--- a/vendor/device.te
+++ b/vendor/device.te
@@ -1,5 +1,4 @@
 type avtimer_device, dev_type;
-type bt_device, dev_type;
 type diag_device, dev_type, mlstrustedobject;
 type dpl_ctl_device, dev_type;
 type efs_boot_device, dev_type;

--- a/vendor/hal_bluetooth_default.te
+++ b/vendor/hal_bluetooth_default.te
@@ -1,4 +1,3 @@
-allow hal_bluetooth_default bt_device:chr_file rw_file_perms;
 allow hal_bluetooth_default serial_device:chr_file rw_file_perms;
 
 rw_diag_device(hal_bluetooth_default)


### PR DESCRIPTION
AOSP recently added a predefined `bt_device` to their `sepolicy` tree (with the build system appropriately complaining about a duplicate) together with the necessary permissions on `hal_bluetooth_default`. We however have to maintain the `file_contexts` to select the right "vendor"-specific `/dev` file that gets this label.

https://cs.android.com/android/_/android/platform/system/sepolicy/+/9ff34235270d3fbe7e7a39d6bb53f2dc1b2d533d
