### PR TITLE
Remove dtbo_block_device which is defined in AOSP since QPR2

### DIFF
--- a/vendor/device.te
+++ b/vendor/device.te
@@ -26,6 +26,5 @@ type fingerprint_device, dev_type;
 type ab_block_device, dev_type;
 type xbl_block_device, dev_type;
 type wlan_device, dev_type;
-type dtbo_block_device, dev_type;
 type vbmeta_block_device, dev_type;
 type hvdcp_opti_device, dev_type;


### PR DESCRIPTION
Ref Repo : https://android.googlesource.com/platform/system/sepolicy/+/refs/tags/android-14.0.0_r30/public/device.te#99
Ref Commit : https://android.googlesource.com/platform/system/sepolicy/+/5d0ef8448f165bdfe59b01d822798a3276c6ca09

Error : device/sony/sepolicy/vendor/device.te:30:ERROR 'Duplicate declaration of type' at token ';'
 on line 90868:
type dtbo_block_device, dev_type;