### PR TITLE
[T/U] file_contexts: Drop executable label for custom health HAL

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -137,7 +137,6 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@[0-9]+\.[0-9]+-service-qti            u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.3-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0
-/(system/vendor|vendor)/bin/hw/android\.hardware\.health@2\.0-service\.sony                  u:object_r:hal_health_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.usb\@1\.[0-2]-service-qti                  u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.allocator-service             u:object_r:hal_graphics_allocator_default_exec:s0


### PR DESCRIPTION
Closes https://github.com/sonyxperiadev/device-sony-sepolicy/pull/611, CC @ShujathMohd

Since the migration to `health@2.1` in [#918] we're using the builtin passthrough service that loads our custom implementation from an `impl` library.  Android's builtin vendor sepolicy already labels this binary with `hal_health_default_exec`, and the `2.0-service.sony` file is no longer provided and should be removed.

[#918]: https://github.com/sonyxperiadev/device-sony-common/pull/918
