### PR TITLE
[t-mr1] vendor: Add SEpolicy for AIDL QTI camera provider

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -60,6 +60,7 @@
 # files in /odm
 /odm/bin/hw/vendor\.qti\.spu@1\.0-service                         u:object_r:spu_exec:s0
 /odm/bin/hw/vendor\.qti\.hardware\.qseecom@1\.0-service           u:object_r:tee_exec:s0
+/odm/bin/hw/vendor\.qti\.camera\.provider-service_64              u:object_r:hal_camera_default_exec:s0
 /odm/bin/hw/vendor\.somc\.hardware\.modemswitcher@1\.0-service    u:object_r:hal_modemsw_default_exec:s0
 /odm/bin/hw/vendor\.somc\.hardware\.miscta@1\.0-service           u:object_r:hal_miscta_default_exec:s0
 /odm/bin/hw/android\.hardware\.authsecret@1\.0-service-qti        u:object_r:hal_authsecret_default_exec:s0

--- a/vendor/hwservice_contexts
+++ b/vendor/hwservice_contexts
@@ -31,3 +31,6 @@ com.qualcomm.qti.dpm.api::IdpmQmi                                       u:object
 # SoMC modem switcher:
 vendor.somc.hardware.miscta::IMisctaGlobal                              u:object_r:vnd_somc_miscta_hwservice:s0
 vendor.somc.hardware.modemswitcher::IModemSwitcher                      u:object_r:vnd_somc_modemswitcher_hwservice:s0
+# QTI camera:
+vendor.qti.hardware.camera.aon::IAONService                             u:object_r:hal_camera_hwservice:s0
+vendor.qti.hardware.camera.postproc::IPostProcService                   u:object_r:hal_camera_hwservice:s0

--- a/vendor/service_contexts
+++ b/vendor/service_contexts
@@ -1,0 +1,2 @@
+# QTI camera:
+android.hardware.camera.provider.ICameraProvider/vendor_qti/0           u:object_r:hal_camera_service:s0


### PR DESCRIPTION
New QTI camera provider is used by k5.15+ devices.
Add vendor.qti.camera.provider-service_64 to file_contexts.
Also add permissions for AON and PostProc camera services.