### PR TITLE
[u-mr1] file_contexts: Add BootControl AIDL HAL

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -141,6 +141,7 @@
 /(system/vendor|vendor)/bin/timekeep                                                         u:object_r:timekeep_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.biometrics\.fingerprint@2\.1-service\.sony u:object_r:hal_fingerprint_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.bluetooth@1\.0-service-qti                 u:object_r:hal_bluetooth_default_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.boot-service\.qti                          u:object_r:hal_bootctl_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@[0-9]+\.[0-9]+-service-qti            u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health-service\.sony                       u:object_r:hal_health_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0


### PR DESCRIPTION
We are going to switch BootControl to AIDL implementation.
Label android.hardware.boot-service.qti AIDL service.