### PR TITLE
[u-mr1] file_contexts: Switch to GNSS AIDL HAL

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -143,7 +143,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.biometrics\.fingerprint@2\.1-service\.sony u:object_r:hal_fingerprint_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.bluetooth@1\.0-service-qti                 u:object_r:hal_bluetooth_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.boot-service\.qti                          u:object_r:hal_bootctl_default_exec:s0
-/(system/vendor|vendor)/bin/hw/android\.hardware\.gnss@[0-9]+\.[0-9]+-service-qti            u:object_r:hal_gnss_qti_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.gnss-aidl-service-qti                      u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health-service\.sony                       u:object_r:hal_health_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.3-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0


### PR DESCRIPTION
We are going to switch GNSS to AIDL implementation.
Label android.hardware.gnss-aidl-service-qti AIDL service.