### PR TITLE
[u-mr1] file_contexts: Switch to Vibrator AIDL HAL

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -151,7 +151,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.usb\@1\.[0-2]-service-qti                  u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.allocator-service             u:object_r:hal_graphics_allocator_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.composer-service              u:object_r:hal_graphics_composer_default_exec:s0
-/(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.vibrator@1\.2-service                  u:object_r:hal_vibrator_default_exec:s0
+/(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.vibrator\.service                      u:object_r:hal_vibrator_default_exec:s0
 
 # sysfs paths
 # Input device control nodes, mainly for CASH to control power


### PR DESCRIPTION
We are going to switch vibrator to AIDL implementation.
Label vendor.qti.hardware.vibrator.service AIDL service.
The QTI Vibrator AIDL HAL can handle all hardware from
Seine to Yodo.