### PR TITLE
[u-mr1] file_contexts: Add NXP NFC AIDL HAL

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -32,6 +32,7 @@
 /dev/sg[0-9]+                                   u:object_r:sg_device:s0
 /dev/sensors                                    u:object_r:sensors_device:s0
 /dev/pn5[0-9x]+                                 u:object_r:nfc_device:s0
+/dev/nq-nci                                     u:object_r:nfc_device:s0
 /dev/smem_log                                   u:object_r:smem_log_device:s0
 /dev/fingerprint                                u:object_r:fingerprint_device:s0
 /dev/dri/card0                                  u:object_r:graphics_device:s0

--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -147,6 +147,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.gnss-aidl-service-qti                      u:object_r:hal_gnss_qti_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.health-service\.sony                       u:object_r:hal_health_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.nfc-service\.nxp                           u:object_r:hal_nfc_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.3-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.usb\@1\.[0-2]-service-qti                  u:object_r:hal_usb_default_exec:s0


### PR DESCRIPTION
We are going to switch NXP NFC HAL to AIDL implementation.
Label android.hardware.nfc-service.nxp AIDL service.