### PR TITLE
[master] file_contexts: Switch to QCOM power AIDL HAL

### DIFF
--- a/vendor/file_contexts
+++ b/vendor/file_contexts
@@ -149,7 +149,7 @@
 /(system/vendor|vendor)/bin/hw/android\.hardware\.light@2\.0-service\.sony                   u:object_r:hal_light_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.nfc-service\.nxp                           u:object_r:hal_nfc_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.drm@1\.3-service(-lazy)?\.clearkey         u:object_r:hal_drm_clearkey_exec:s0
-/(system/vendor|vendor)/bin/hw/android\.hardware\.power@1\.3-service\.sony                   u:object_r:hal_power_default_exec:s0
+/(system/vendor|vendor)/bin/hw/android\.hardware\.power-service                              u:object_r:hal_power_default_exec:s0
 /(system/vendor|vendor)/bin/hw/android\.hardware\.usb\@1\.[0-2]-service-qti                  u:object_r:hal_usb_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.allocator-service             u:object_r:hal_graphics_allocator_default_exec:s0
 /(system/vendor|vendor)/bin/hw/vendor\.qti\.hardware\.display\.composer-service              u:object_r:hal_graphics_composer_default_exec:s0


### PR DESCRIPTION
We are going to switch power HAL to QCOM AIDL implementation.
Our current implementation hasn’t worked for years and only
exists as a stub, because it depends on a custom RQBalance
governor in the Linux kernel.